### PR TITLE
Feat/update committee index

### DIFF
--- a/packages/committee-generator/src/s3/index.ts
+++ b/packages/committee-generator/src/s3/index.ts
@@ -198,6 +198,8 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
     fromRound: number;
     toRound: number;
     committeeId: string;
+    totalMembers: number;
+    totalVotes: number;
   }> = [];
 
   for (const key of keys) {
@@ -231,6 +233,8 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
         fromRound,
         toRound,
         committeeId: committeeID,
+        totalMembers: committee.totalMembers,
+        totalVotes: committee.totalVotes,
       });
 
       if (endRoundExists && committeeIDExists) {
@@ -294,11 +298,18 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
       console.log('Creating committee index file...');
     }
 
-    // Sort by fromRound for easier navigation
-    indexEntries.sort((a, b) => a.fromRound - b.fromRound);
+    // Sort by toRound for consistent ordering
+    indexEntries.sort((a, b) => a.toRound - b.toRound);
+
+    const committeesToRound = Object.fromEntries(
+      indexEntries.map(({ fromRound, toRound, committeeId, totalMembers, totalVotes }) => [
+        toRound,
+        { fromRound, toRound, committeeId, totalMembers, totalVotes },
+      ]),
+    );
 
     const indexData = {
-      committees: indexEntries,
+      committees: committeesToRound,
       lastUpdated: new Date().toISOString(),
       totalCommittees: indexEntries.length,
     };

--- a/packages/committee-generator/test/s3/ensure-committee-shortcuts.test.ts
+++ b/packages/committee-generator/test/s3/ensure-committee-shortcuts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { PutObjectCommand, ListObjectsV2Command, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files';
 import { createCommitteeFixture, getExpectedKey, cleanupS3Prefix } from './helpers';
 import type { Committee } from '../../src/committee';
@@ -188,5 +188,95 @@ describe('ensureCommitteeShortcuts', () => {
     );
 
     expect(listResult.Contents).toHaveLength(4);
+  });
+
+  it('should generate index.json with correct structure and data', async () => {
+    const { s3Client } = getGlobalLocalStack();
+
+    // Create 2 committees with different data
+    const committee1 = createCommitteeFixture(55000000, 58000000);
+    const committee2 = createCommitteeFixture(55005000, 58005000);
+
+    committeeStore.set('55000000-58000000', committee1);
+    committeeStore.set('55005000-58005000', committee2);
+
+    // Upload committee files to S3
+    const key1 = getExpectedKey('committee/55000000-58000000.json');
+    const key2 = getExpectedKey('committee/55005000-58005000.json');
+
+    await Promise.all([
+      s3Client.send(
+        new PutObjectCommand({
+          Bucket: TEST_BUCKET_NAME,
+          Key: key1,
+          Body: JSON.stringify(committee1),
+        }),
+      ),
+      s3Client.send(
+        new PutObjectCommand({
+          Bucket: TEST_BUCKET_NAME,
+          Key: key2,
+          Body: JSON.stringify(committee2),
+        }),
+      ),
+    ]);
+
+    // Run the function
+    const { ensureCommitteeShortcuts } = await import('../../src/s3');
+    await ensureCommitteeShortcuts();
+
+    // Fetch index.json
+    const indexKey = getExpectedKey('committee/index.json');
+    const getResult = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: TEST_BUCKET_NAME,
+        Key: indexKey,
+      }),
+    );
+
+    // Parse the JSON
+    const body = await getResult.Body?.transformToString();
+    if (!body) {
+      throw new Error(`Expected S3 object body for key "${indexKey}", but got none`);
+    }
+    const index = JSON.parse(body);
+
+    // Validate structure
+    expect(index).toHaveProperty('committees');
+    expect(index).toHaveProperty('lastUpdated');
+    expect(index).toHaveProperty('totalCommittees');
+    expect(typeof index.committees).toBe('object');
+    expect(Array.isArray(index.committees)).toBe(false); // Should be object, not array
+
+    // Validate committees object is keyed by toRound
+    const committeeKeys = Object.keys(index.committees);
+    expect(committeeKeys).toContain('58000000');
+    expect(committeeKeys).toContain('58005000');
+    expect(committeeKeys).toHaveLength(2);
+
+    // Validate sorting order (by toRound ascending)
+    const sortedKeys = committeeKeys.map(Number).sort((a, b) => a - b);
+    expect(committeeKeys.map(Number)).toEqual(sortedKeys);
+
+    // Validate first committee entry
+    const entry1 = index.committees['58000000'];
+    expect(entry1.fromRound).toBe(55000000);
+    expect(entry1.toRound).toBe(58000000);
+    expect(entry1.totalMembers).toBe(committee1.totalMembers);
+    expect(entry1.totalVotes).toBe(committee1.totalVotes);
+    expect(typeof entry1.committeeId).toBe('string');
+    expect(entry1.committeeId.length).toBeGreaterThan(0);
+
+    // Validate second committee entry
+    const entry2 = index.committees['58005000'];
+    expect(entry2.fromRound).toBe(55005000);
+    expect(entry2.toRound).toBe(58005000);
+    expect(entry2.totalMembers).toBe(committee2.totalMembers);
+    expect(entry2.totalVotes).toBe(committee2.totalVotes);
+    expect(typeof entry2.committeeId).toBe('string');
+
+    // Validate metadata
+    expect(index.totalCommittees).toBe(2);
+    expect(new Date(index.lastUpdated).getTime()).toBeLessThanOrEqual(Date.now());
   });
 });


### PR DESCRIPTION
To provide more efficient lookup of committees and avoid multiple requests to get total votes or total members we can make the committees `index.json` a map with the `toRound` as the key, preserving the information from the prior format

Now generated `.../committee/index.json` file will look like this (crud test data, in production will always be aligned to 1_000_000 from-to ranges):

```json
{
  "committees": {
    "53002000": {
      "fromRound": 53000000,
      "toRound": 53002000,
      "committeeId": "9+n80hLTgFtpOLU1NRDBTS+UpY4ME/SRxZcmvcX5Ryw=",
      "totalMembers": 19,
      "totalVotes": 25
    },
    "55005000": {
      "fromRound": 55000000,
      "toRound": 55005000,
      "committeeId": "RKyhuPp15oR33Rct5ah2sPioYomQ44FUJbcwstfdpuM=",
      "totalMembers": 57,
      "totalVotes": 901
    },
    "55010000": {
      "fromRound": 55000000,
      "toRound": 55010000,
      "committeeId": "tB7KGu6kN/calva7Tr2QzAYm1fEfQqKF6pHKOZdwKNs=",
      "totalMembers": 77,
      "totalVotes": 1733
    },
    "55015000": {
      "fromRound": 55000000,
      "toRound": 55015000,
      "committeeId": "cLIpuMMPEgL7vfPzCFUXh9bITYVwEG43p1m5tOUANVE=",
      "totalMembers": 95,
      "totalVotes": 2579
    },
    "55020000": {
      "fromRound": 55015000,
      "toRound": 55020000,
      "committeeId": "83nFDdUU+Bcmzn5bSAByPeNDH/zwVnwpxTM20qIHXRc=",
      "totalMembers": 55,
      "totalVotes": 812
    },
    "56020000": {
      "fromRound": 56015000,
      "toRound": 56020000,
      "committeeId": "QszVn9GVlQPlt2WskEaZw56gVP9oWcK7czeFAl8DxBw=",
      "totalMembers": 53,
      "totalVotes": 894
    },
    "58000000": {
      "fromRound": 55000000,
      "toRound": 58000000,
      "committeeId": "4ffYWWJh6jouRH0x6Re9oEbmWu40K9F8ukhRQ1teCpQ=",
      "totalMembers": 162,
      "totalVotes": 508887
    },
    "58010000": {
      "fromRound": 55000000,
      "toRound": 58010000,
      "committeeId": "onc1MzIGInq4dqzIwYK+1X+7vPZEXLeZXpSe7TNb+oE=",
      "totalMembers": 162,
      "totalVotes": 510478
    },
    "58974000": {
      "fromRound": 58973000,
      "toRound": 58974000,
      "committeeId": "biaF6JccGazUtVCGoG404bwv+vIWbXWwKWGh4amqsD8=",
      "totalMembers": 30,
      "totalVotes": 168
    },
    "58976000": {
      "fromRound": 58973000,
      "toRound": 58976000,
      "committeeId": "akGJoLg/HIhpT0VVj9WYHiJItjQ8O1WWjxNwkXs4cPo=",
      "totalMembers": 43,
      "totalVotes": 454
    }
  },
  "lastUpdated": "2026-03-20T10:35:45.865Z",
  "totalCommittees": 11
}
```

- [x] Is `totalCommittees` needed? (already existing property). I think it provides a useful reference, since we calculate and validate in advance.