### PR TITLE
refactor: period based runner

### DIFF
--- a/packages/runner/.gitignore
+++ b/packages/runner/.gitignore
@@ -1,5 +1,2 @@
 state
 coverage
-# ignored until ready
-README.md
-CONTRIBUTING.md

--- a/packages/runner/CONTRIBUTING.md
+++ b/packages/runner/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+## Test architecture
+
+Tests are split into three suites:
+
+| Suite           | Location            | Requirements     |
+| --------------- | ------------------- | ---------------- |
+| **unit**        | `test/unit/`        | Nothing external |
+| **integration** | `test/integration/` | Mainnet algod    |
+| **systemd**     | `test/systemd/`     | Docker           |
+
+All suites share test fixtures in `test/fixtures/`.
+
+**Unit** — isolated logic with all dependencies mocked.
+
+**Integration** — spawns the runner as a child process. Fakes `systemd-notify` with a no-op script. Tests exit codes, signal handling (SIGTERM/SIGKILL escalation), child process cleanup, state bootstrapping, and error paths. No Docker, no systemd.
+
+**Systemd** — boots a privileged Docker container with systemd as PID 1. Five scenarios via `run-test-container.sh <scenario>`:
+
+| Scenario  | What it tests                                                                |
+| --------- | ---------------------------------------------------------------------------- |
+| `verify`  | Static lint of `.service` and `.timer` unit files (`systemd-analyze verify`) |
+| `boot`    | Timer triggers on boot, `Type=notify` + `READY=1` handshake, clean exit      |
+| `stop`    | `systemctl stop` → SIGTERM → runner and child exit cleanly                   |
+| `failure` | Fatal generator exit → `ExecStopPost` runs `notify-slack`                    |
+| `no-env`  | Missing `.env` causes a hard failure, not a silent skip                      |
+
+`pnpm test` runs unit + integration only. Systemd tests need privileged Docker — run them with `pnpm run test:systemd`.
+
+## Coverage
+
+`pnpm run test:coverage` runs unit + integration with v8 coverage. All source files reach 100% except `index.ts` (the process entry point). v8 can't instrument it because integration tests spawn it as a subprocess, but those tests cover all its paths.
+
+## Keeping in sync with committee-generator
+
+The runner spawns the committee generator as a child process. They share no build-time dependencies, but the runner hard-codes parts of the generator's interface:
+
+| What                                              | Runner location                               | Generator source                                                                      |
+| ------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Exit codes (`SUCCESS`, `FATAL`, `EXPECTED_TIP`)   | `src/service.ts` → `GENERATOR_EXIT_CODE`      | `src/exit-codes.ts` → `ExitCode`                                                      |
+| CLI args (`--mode`, `--from-block`, `--to-block`) | `src/service.ts` → `spawnWriteCache`          | Generator's CLI arg parser                                                            |
+| SIGTERM grace period                              | `src/index.ts` → `GENERATOR_SIGTERM_GRACE_MS` | Generator's SIGTERM handler — grace period must exceed the generator's max flush time |
+
+## Testing notify-slack locally
+
+The `notify-slack.js` script posts a Slack notification when the runner service fails. To test locally add credentials to `.env` at the **workspace root** (loaded by `src/env.ts` via dotenv):
+
+```env
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_CHANNEL_ID=C...
+```
+
+Build and run:
+
+```bash
+pnpm run build
+
+# Success — no Slack message
+node dist/notify-slack.js --exit-status 0 --service-result success --hostname local
+
+# Failure — posts to Slack
+node dist/notify-slack.js --exit-status 1 --service-result exit-code --hostname local
+
+# Other failure types
+node dist/notify-slack.js --exit-status 0 --service-result timeout --hostname local
+node dist/notify-slack.js --exit-status 0 --service-result watchdog --hostname local
+```

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,0 +1,87 @@
+# xGov Committees Runner
+
+A systemd service that tracks [ARC-86](https://dev.algorand.co/arc-standards/arc-0086/) governance periods and spawns the committee generator to build block-header caches and compute xGov committees.
+
+Triggered by a systemd timer every 50 minutes. See [systemd/README.md](systemd/README.md) for unit configuration.
+
+## How it works
+
+Per [ARC-86](https://dev.algorand.co/arc-standards/arc-0086/), an xGov Committee is selected from a governance period `(Bi, Bf)` — the block range `[Bi; Bf)` from which xGov voting power is derived. Each xGov's voting power equals the number of blocks they proposed in that range. Consecutive governance periods shift by 1M blocks: `(Bi, Bf)` → `(Bi+1M, Bf+1M)`, with `Bf - Bi = 3M` blocks (the committee selection range).
+
+The runner tracks the last fully processed governance period and warms the cache for the next one. On each invocation the service loop evaluates three ordered cases:
+
+1. **Catch-up** — If the chain is already past `Bf`, process the full `[Bi; Bf)` range immediately. This handles bootstrapping and periods that were missed while the service was offline.
+2. **Close to period end** — If the chain is within 900 blocks of `Bf`, wait for it (plus a short buffer), then process the full range.
+3. **100K warming** — If a 100K-block boundary has been crossed since the last write-cache call, run the generator over `[Bi; Bf)` with `retryOnTip=false` (tip is expected and accepted silently). This keeps the block-header cache warm so that the final committee calculation at `Bf` is fast.
+
+After each case the loop re-evaluates, so a single invocation can catch up across multiple governance periods and then warm the cache for the current one.
+
+### State file
+
+The runner persists a JSON state file per network/registry pair in `STATE_DIR`:
+
+```json
+{
+  "lastGovernancePeriod": { "Bi": 56000000, "Bf": 59000000 },
+  "lastCacheRound": 59112478,
+  "updatedAt": "2026-03-20T12:00:00.000Z"
+}
+```
+
+- `lastGovernancePeriod` — the last fully processed governance period `(Bi, Bf)`.
+- `lastCacheRound` — the last round at which a successful write-cache call was made.
+
+On first run the runner bootstraps from the initial governance period `(50M, 53M)`.
+
+## Quick start
+
+```bash
+pnpm install
+pnpm run build        # compile to dist/
+pnpm run typecheck    # type-check only
+pnpm run lint:fix     # lint + auto-fix
+pnpm run format       # format code
+```
+
+## Testing
+
+```bash
+pnpm test                        # unit + integration
+pnpm run test:unit               # unit only
+pnpm run test:integration        # integration only (needs mainnet algod)
+pnpm run test:integration:slack  # integration + live Slack post (needs .env)
+pnpm run test:systemd            # systemd lifecycle tests (needs Docker)
+pnpm run test:systemd:slack      # systemd failure → live Slack post (needs .env + Docker)
+pnpm run test:coverage           # unit + integration with v8 coverage
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for test architecture, coverage details, and sync requirements with `committee-generator`.
+
+## Configuration
+
+All variables have production defaults except Slack credentials, which are **required**.
+
+| Variable                   | Default                                                           | Description                      |
+| -------------------------- | ----------------------------------------------------------------- | -------------------------------- |
+| `SLACK_BOT_TOKEN`          | —                                                                 | **Required.** Slack bot token    |
+| `SLACK_CHANNEL_ID`         | —                                                                 | **Required.** Slack channel ID   |
+| `ALGOD_SERVER`             | `https://mainnet-api.4160.nodely.dev`                             | Algod server URL                 |
+| `ALGOD_PORT`               | `443`                                                             | Algod port                       |
+| `ALGOD_TOKEN`              | _(empty)_                                                         | Algod API token                  |
+| `REGISTRY_APP_ID`          | `3147789458`                                                      | xGov Registry app ID (mainnet)   |
+| `STATE_DIR`                | `/var/lib/xgov-committees-runner`                                 | Directory for runner state files |
+| `COMMITTEE_GENERATOR_PATH` | `/opt/xgov-committees/packages/committee-generator/dist/index.js` | Path to committee generator      |
+
+Override via environment variables or an `.env` file at `/opt/xgov-committees/.env` (loaded by the systemd unit).
+
+## Deploy
+
+The service expects the full monorepo at `/opt/xgov-committees/`, built from the root with `pnpm install && pnpm run build` (builds both `runner` and `committee-generator`).
+
+**Requirements:**
+
+- Node.js >= 20.19.0 and pnpm on the server
+- A dedicated `xgov-committees-runner` system user (the service runs unprivileged)
+- A `.env` file at `/opt/xgov-committees/.env` with `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` (see [Configuration](#configuration)). Must be readable by the service user's group (`root:xgov-committees-runner`, mode `640`)
+- A state directory at `/var/lib/xgov-committees-runner` owned by the service user
+- The systemd units from `systemd/` installed in `/etc/systemd/system/` — see [systemd/README.md](systemd/README.md) for unit configuration details

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -6,7 +6,7 @@ Triggered by a systemd timer every 50 minutes. See [systemd/README.md](systemd/R
 
 ## How it works
 
-Per [ARC-86](https://dev.algorand.co/arc-standards/arc-0086/), an xGov Committee is selected from a governance period `(Bi, Bf)` — the block range `[Bi; Bf)` from which xGov voting power is derived. Each xGov's voting power equals the number of blocks they proposed in that range. Consecutive governance periods shift by 1M blocks: `(Bi, Bf)` → `(Bi+1M, Bf+1M)`, with `Bf - Bi = 3M` blocks (the committee selection range).
+Per ARC-86, an xGov Committee is selected from a governance period `(Bi, Bf)` — the block range `[Bi; Bf)` from which xGov voting power is derived. Each xGov's voting power equals the number of blocks they proposed in that range. Consecutive governance periods shift by 1M blocks: `(Bi, Bf)` → `(Bi+1M, Bf+1M)`, with `Bf - Bi = 3M` blocks (the committee selection range). Once the chain passes `Bf`, the committee for that period can be computed and a new committee file is generated.
 
 The runner tracks the last fully processed governance period and warms the cache for the next one. On each invocation the service loop evaluates three ordered cases:
 

--- a/packages/runner/src/service.ts
+++ b/packages/runner/src/service.ts
@@ -3,11 +3,17 @@ import { setTimeout } from "node:timers/promises";
 import { spawn, type ChildProcess } from "node:child_process";
 import { AlgorandClient } from "@algorandfoundation/algokit-utils";
 import { type Config } from "./config.ts";
-import { loadState, saveState } from "./state.ts";
-import { crossed100KBoundary, closeTo1MBoundary, next1MBoundary } from "./utils.ts";
+import {
+  type GovernancePeriod,
+  type RunnerState,
+  INITIAL_PERIOD,
+  COHORT_VALIDITY_RANGE,
+  loadState,
+  saveState,
+} from "./state.ts";
+import { crossed100KBoundary, closeTo1MBoundary } from "./utils.ts";
 
-const ROUND_BUFFER = 21; // ~1m at 2.8s per block
-const FIRST_SYNC_ROUND = 50_000_000;
+const TIP_BUFFER = 21; // ~1m at 2.8s per block
 
 // Mirrors committee-generator's ExitCode
 const GENERATOR_EXIT_CODE = {
@@ -23,10 +29,9 @@ export function getActiveChild(): ChildProcess | null {
 }
 
 /**
- * Spawns the committee generator in write-cache mode for [fromBlock, toBlock].
+ * Spawns the committee generator in write-cache mode with (fromBlock, toBlock) arguments.
  * Resolves "success" or "tip" (generator hit the chain tip before toBlock).
- * Rejects on fatal exit or spawn error.
- * TODO: verify inclusive/exclusive block range with generator.
+ * Rejects on generator's fatal exit or spawn error.
  */
 function spawnWriteCache(generatorPath: string, fromBlock: number, toBlock: number): Promise<"success" | "tip"> {
   return new Promise((resolve, reject) => {
@@ -58,7 +63,7 @@ function spawnWriteCache(generatorPath: string, fromBlock: number, toBlock: numb
 
 /**
  * Polls algod until the chain reaches targetRound.
- * Necessary because the statusAfterBlock times out after 1 minute.
+ * Necessary because statusAfterBlock times out after 1 minute.
  */
 export async function waitForBlock(algorand: AlgorandClient, targetRound: number): Promise<void> {
   while (true) {
@@ -73,30 +78,68 @@ export async function waitForBlock(algorand: AlgorandClient, targetRound: number
 }
 
 /**
- * Runs write-cache for [from, to], retrying once if the generator hits the chain tip.
- * On tip, waits for block `to + ROUND_BUFFER` before retrying with the same range.
- * Throws if tip is hit twice.
+ * Runs generator's write-cache mode, handling the case where the generator hits the chain tip.
+ *
+ * If retryOnTip is true, retries once if the generator hits the chain tip and throws if tip is hit twice.
+ * If retryOnTip is false, accepts "tip" silently and returns.
  */
 export async function runWriteCache(
   algorand: AlgorandClient,
   generatorPath: string,
   from: number,
   to: number,
+  retryOnTip: boolean = true,
 ): Promise<void> {
   const result = await spawnWriteCache(generatorPath, from, to);
   if (result === "tip") {
-    console.log(`generator reached chain tip, waiting for block ${to + ROUND_BUFFER} then retrying`);
-    await waitForBlock(algorand, to + ROUND_BUFFER);
+    if (!retryOnTip) {
+      console.log(`committee-generator reached chain tip (expected for warming), continuing`);
+      return;
+    }
+    console.log(`committee-generator reached chain tip, waiting for block ${to + TIP_BUFFER}, then retrying`);
+    await waitForBlock(algorand, to + TIP_BUFFER);
     const retry = await spawnWriteCache(generatorPath, from, to);
     if (retry === "tip") {
-      throw new Error(`generator reached chain tip even after retrying with ${ROUND_BUFFER}-round buffer`);
+      throw new Error(`committee-generator reached chain tip even after retrying with ${TIP_BUFFER}-round buffer`);
     }
   }
 }
 
 /**
+ * Loads local state handling the case where no state file exists.
+ * In the bootstrap case, makes a fake state that signals the service to start processing from the first-ever
+ * governance period.
+ */
+function getState(config: Config, genesisHash: string): Omit<RunnerState, "updatedAt"> {
+  const state = loadState(config.stateDir, genesisHash, config.registryAppId);
+  if (state != null) return state;
+  else {
+    console.log(
+      `No state file found — bootstrapping from first governance period (${INITIAL_PERIOD.Bi}, ${INITIAL_PERIOD.Bf}) (\`write-cache\` mode is idempotent)`,
+    );
+    return {
+      lastGovernancePeriod: {
+        Bi: INITIAL_PERIOD.Bi - COHORT_VALIDITY_RANGE,
+        Bf: INITIAL_PERIOD.Bf - COHORT_VALIDITY_RANGE,
+      },
+      lastCacheRound: 0,
+    };
+  }
+}
+
+/**
+ * Calculates the next governance period based on the last processed one.
+ */
+function nextGovernancePeriod(lastProcessed: GovernancePeriod): GovernancePeriod {
+  return {
+    Bi: lastProcessed.Bi + COHORT_VALIDITY_RANGE,
+    Bf: lastProcessed.Bf + COHORT_VALIDITY_RANGE,
+  };
+}
+
+/**
  * Runs the service loop until all run conditions are handled.
- * Re-evaluates after each write-cache op in case new boundaries are met (e.g. 100K sync may get close to 1M boundary).
+ * Re-evaluates after each write-cache op in case run conditions are met.
  */
 export async function run(config: Config): Promise<void> {
   const algorand = AlgorandClient.fromConfig({
@@ -107,60 +150,67 @@ export async function run(config: Config): Promise<void> {
     },
   });
 
+  const params = await algorand.client.algod.getTransactionParams().do();
+  const genesisHash = Buffer.from(params.genesisHash).toString("base64");
+
   mkdirSync(config.stateDir, { recursive: true });
-  let runCounter = 0;
+
+  let loopCounter = 0;
 
   while (true) {
-    runCounter++;
-    let wroteCache = false;
-    const params = await algorand.client.algod.getTransactionParams().do();
-    const genesisHash = Buffer.from(params.genesisHash).toString("base64");
-    let currentRound = Number(params.firstValid);
+    loopCounter++;
+    const { firstValid } = await algorand.client.algod.getTransactionParams().do();
+    const currentRound = Number(firstValid);
 
-    const state = loadState(config.stateDir, genesisHash, config.registryAppId);
-    if (state === null) {
-      console.log(
-        `No state file found — bootstrapping from round ${FIRST_SYNC_ROUND} (\`write-cache\` mode is idempotent)`,
-      );
-    }
-    const nextRoundToProcess = (state?.lastProcessedRound ?? FIRST_SYNC_ROUND - 1) + 1;
+    const state = getState(config, genesisHash);
+    const { Bi, Bf } = nextGovernancePeriod(state.lastGovernancePeriod);
 
-    if (runCounter === 1) console.log(`genesis: ${genesisHash}, registry: ${config.registryAppId}`);
-    console.log(`[#${runCounter}] round ${currentRound}, next to process: ${nextRoundToProcess}`);
+    if (loopCounter === 1) console.log(`genesis: ${genesisHash}; registry: ${config.registryAppId}`);
+    console.log(`[#${loopCounter}] - current round ${currentRound}; processing period: (${Bi}, ${Bf})`);
 
-    if (currentRound <= nextRoundToProcess) {
-      if (runCounter === 1)
+    if (currentRound <= state.lastCacheRound) {
+      if (loopCounter === 1)
         throw new Error(
-          `algod returned round ${currentRound} which is not ahead of the next round to process ${nextRoundToProcess}`,
+          `algod returned round ${currentRound} which is not ahead of the last cache warm round ${state.lastCacheRound}`,
         );
-      console.log(`caught up at round ${currentRound - 1}, exiting`);
+      console.log(`caught up at round ${state.lastCacheRound}, exiting`);
       break;
     }
 
-    if (crossed100KBoundary(nextRoundToProcess, currentRound)) {
-      console.log(`100K boundary crossed, write-cache ${nextRoundToProcess}–${currentRound}`);
-      await runWriteCache(algorand, config.committeeGeneratorPath, nextRoundToProcess, currentRound);
-      wroteCache = true;
+    async function handlePeriodEnd() {
+      await runWriteCache(algorand, config.committeeGeneratorPath, Bi, Bf);
+      saveState(config.stateDir, genesisHash, config.registryAppId, {
+        lastGovernancePeriod: { Bi, Bf },
+        lastCacheRound: Bf,
+        updatedAt: new Date().toISOString(),
+      });
     }
 
-    if (closeTo1MBoundary(currentRound)) {
-      const target = next1MBoundary(currentRound);
-      console.log(`approaching 1M boundary at ${target}, waiting...`);
-      await waitForBlock(algorand, target + ROUND_BUFFER);
-
-      const from = crossed100KBoundary(nextRoundToProcess, currentRound) ? currentRound + 1 : nextRoundToProcess;
-      currentRound = target;
-
-      console.log(`1M boundary crossed, write-cache ${from}–${target}`);
-      await runWriteCache(algorand, config.committeeGeneratorPath, from, target);
-      wroteCache = true;
+    async function handleCatchUp() {
+      console.log(`catch-up: all blocks available, calling write-cache with (${Bi}, ${Bf})`);
+      await handlePeriodEnd();
     }
 
-    if (!wroteCache) break;
+    async function handleApproachingPeriodEnd() {
+      console.log(`approaching period end at ${Bf}, waiting...`);
+      await waitForBlock(algorand, Bf + TIP_BUFFER);
+      console.log(`period end reached: all blocks available, calling write-cache with (${Bi}, ${Bf})`);
+      await handlePeriodEnd();
+    }
 
-    saveState(config.stateDir, genesisHash, config.registryAppId, {
-      lastProcessedRound: currentRound,
-      updatedAt: new Date().toISOString(),
-    });
+    async function handleBoundaryCrossed() {
+      console.log(`100K boundary crossed since last cache update, calling write-cache with (${Bi}, ${Bf})`);
+      await runWriteCache(algorand, config.committeeGeneratorPath, Bi, Bf, false);
+      saveState(config.stateDir, genesisHash, config.registryAppId, {
+        ...state,
+        lastCacheRound: currentRound,
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    if (currentRound >= Bf) await handleCatchUp();
+    else if (closeTo1MBoundary(currentRound)) await handleApproachingPeriodEnd();
+    else if (crossed100KBoundary(state.lastCacheRound, currentRound)) await handleBoundaryCrossed();
+    else break;
   }
 }

--- a/packages/runner/src/service.ts
+++ b/packages/runner/src/service.ts
@@ -210,7 +210,7 @@ export async function run(config: Config): Promise<void> {
 
     if (currentRound >= Bf) await handleCatchUp();
     else if (closeTo1MBoundary(currentRound)) await handleApproachingPeriodEnd();
-    else if (crossed100KBoundary(state.lastCacheRound, currentRound)) await handleBoundaryCrossed();
+    else if (crossed100KBoundary(state.lastCacheRound + 1, currentRound)) await handleBoundaryCrossed();
     else break;
   }
 }

--- a/packages/runner/src/service.ts
+++ b/packages/runner/src/service.ts
@@ -115,12 +115,12 @@ function getState(config: Config, genesisHash: string): Omit<RunnerState, "updat
   if (state != null) return state;
   else {
     console.log(
-      `No state file found — bootstrapping from first governance period (${INITIAL_PERIOD.Bi}, ${INITIAL_PERIOD.Bf}) (\`write-cache\` mode is idempotent)`,
+      `No state file found — bootstrapping from first governance period (${INITIAL_PERIOD.startRound}, ${INITIAL_PERIOD.endRound}) (\`write-cache\` mode is idempotent)`,
     );
     return {
       lastGovernancePeriod: {
-        Bi: INITIAL_PERIOD.Bi - COHORT_VALIDITY_RANGE,
-        Bf: INITIAL_PERIOD.Bf - COHORT_VALIDITY_RANGE,
+        startRound: INITIAL_PERIOD.startRound - COHORT_VALIDITY_RANGE,
+        endRound: INITIAL_PERIOD.endRound - COHORT_VALIDITY_RANGE,
       },
       lastCacheRound: 0,
     };
@@ -132,8 +132,8 @@ function getState(config: Config, genesisHash: string): Omit<RunnerState, "updat
  */
 function nextGovernancePeriod(lastProcessed: GovernancePeriod): GovernancePeriod {
   return {
-    Bi: lastProcessed.Bi + COHORT_VALIDITY_RANGE,
-    Bf: lastProcessed.Bf + COHORT_VALIDITY_RANGE,
+    startRound: lastProcessed.startRound + COHORT_VALIDITY_RANGE,
+    endRound: lastProcessed.endRound + COHORT_VALIDITY_RANGE,
   };
 }
 
@@ -163,10 +163,10 @@ export async function run(config: Config): Promise<void> {
     const currentRound = Number(firstValid);
 
     const state = getState(config, genesisHash);
-    const { Bi, Bf } = nextGovernancePeriod(state.lastGovernancePeriod);
+    const { startRound, endRound } = nextGovernancePeriod(state.lastGovernancePeriod);
 
     if (loopCounter === 1) console.log(`genesis: ${genesisHash}; registry: ${config.registryAppId}`);
-    console.log(`[#${loopCounter}] - current round ${currentRound}; processing period: (${Bi}, ${Bf})`);
+    console.log(`[#${loopCounter}] - current round ${currentRound}; processing period: (${startRound}, ${endRound})`);
 
     if (currentRound <= state.lastCacheRound) {
       if (loopCounter === 1)
@@ -178,29 +178,31 @@ export async function run(config: Config): Promise<void> {
     }
 
     async function handlePeriodEnd() {
-      await runWriteCache(algorand, config.committeeGeneratorPath, Bi, Bf);
+      await runWriteCache(algorand, config.committeeGeneratorPath, startRound, endRound);
       saveState(config.stateDir, genesisHash, config.registryAppId, {
-        lastGovernancePeriod: { Bi, Bf },
-        lastCacheRound: Bf,
+        lastGovernancePeriod: { startRound, endRound },
+        lastCacheRound: endRound,
         updatedAt: new Date().toISOString(),
       });
     }
 
     async function handleCatchUp() {
-      console.log(`catch-up: all blocks available, calling write-cache with (${Bi}, ${Bf})`);
+      console.log(`catch-up: all blocks available, calling write-cache with (${startRound}, ${endRound})`);
       await handlePeriodEnd();
     }
 
     async function handleApproachingPeriodEnd() {
-      console.log(`approaching period end at ${Bf}, waiting...`);
-      await waitForBlock(algorand, Bf + TIP_BUFFER);
-      console.log(`period end reached: all blocks available, calling write-cache with (${Bi}, ${Bf})`);
+      console.log(`approaching period end at ${endRound}, waiting...`);
+      await waitForBlock(algorand, endRound + TIP_BUFFER);
+      console.log(`period end reached: all blocks available, calling write-cache with (${startRound}, ${endRound})`);
       await handlePeriodEnd();
     }
 
     async function handleBoundaryCrossed() {
-      console.log(`100K boundary crossed since last cache update, calling write-cache with (${Bi}, ${Bf})`);
-      await runWriteCache(algorand, config.committeeGeneratorPath, Bi, Bf, false);
+      console.log(
+        `100K boundary crossed since last cache update, calling write-cache with (${startRound}, ${endRound})`,
+      );
+      await runWriteCache(algorand, config.committeeGeneratorPath, startRound, endRound, false);
       saveState(config.stateDir, genesisHash, config.registryAppId, {
         ...state,
         lastCacheRound: currentRound,
@@ -208,7 +210,7 @@ export async function run(config: Config): Promise<void> {
       });
     }
 
-    if (currentRound >= Bf) await handleCatchUp();
+    if (currentRound >= endRound) await handleCatchUp();
     else if (closeTo1MBoundary(currentRound)) await handleApproachingPeriodEnd();
     else if (crossed100KBoundary(state.lastCacheRound + 1, currentRound)) await handleBoundaryCrossed();
     else break;

--- a/packages/runner/src/state.ts
+++ b/packages/runner/src/state.ts
@@ -2,24 +2,24 @@ import { readFileSync, writeFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
 
 /**
- * @property Bi - period start block (inclusive)
- * @property Bf - period end block (exclusive)
+ * @property startRound - period start block (inclusive); Bi in the xGov docs
+ * @property endRound - period end block (exclusive); Bf in the xGov docs
  *
- * Bi and Bf must be multiples of 1M and satisfy Bi < Bf.
- * The range `Bf - Bi` is the committee selection range, currently 3M blocks - {@link COMMITTEE_SELECTION_RANGE}
+ * startRound and endRound must be multiples of 1M and satisfy startRound < endRound.
+ * The range `endRound - startRound` is the committee selection range, currently 3M blocks - {@link COMMITTEE_SELECTION_RANGE}
  * The first ever governance period is [50M; 53M) - {@link INITIAL_PERIOD}
  * The cohort validity is currently 1M blocks. The cohort validity range is the offset between two consecutive governance periods - {@link COHORT_VALIDITY_RANGE}.
  */
 export interface GovernancePeriod {
-  Bi: number;
-  Bf: number;
+  startRound: number;
+  endRound: number;
 }
 
-export const COMMITTEE_SELECTION_RANGE = 3e6;
-export const COHORT_VALIDITY_RANGE = 1e6;
+export const COMMITTEE_SELECTION_RANGE = 3_000_000;
+export const COHORT_VALIDITY_RANGE = 1_000_000;
 export const INITIAL_PERIOD: GovernancePeriod = {
-  Bi: 50e6,
-  Bf: 50e6 + COMMITTEE_SELECTION_RANGE,
+  startRound: 50_000_000,
+  endRound: 50_000_000 + COMMITTEE_SELECTION_RANGE,
 };
 
 /**

--- a/packages/runner/src/state.ts
+++ b/packages/runner/src/state.ts
@@ -1,9 +1,37 @@
 import { readFileSync, writeFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
 
-interface RunnerState {
-  lastProcessedRound: number;
-  updatedAt: string; // ISO timestamp
+/**
+ * @property Bi - period start block (inclusive)
+ * @property Bf - period end block (exclusive)
+ *
+ * Bi and Bf must be multiples of 1M and satisfy Bi < Bf.
+ * The range `Bf - Bi` is the committee selection range, currently 3M blocks - {@link COMMITTEE_SELECTION_RANGE}
+ * The first ever governance period is [50M; 53M) - {@link INITIAL_PERIOD}
+ * The cohort validity is currently 1M blocks. The cohort validity range is the offset between two consecutive governance periods - {@link COHORT_VALIDITY_RANGE}.
+ */
+export interface GovernancePeriod {
+  Bi: number;
+  Bf: number;
+}
+
+export const COMMITTEE_SELECTION_RANGE = 3e6;
+export const COHORT_VALIDITY_RANGE = 1e6;
+export const INITIAL_PERIOD: GovernancePeriod = {
+  Bi: 50e6,
+  Bf: 50e6 + COMMITTEE_SELECTION_RANGE,
+};
+
+/**
+ * Persisted state of the runner for a given network (`genesisHash`) and registry (`registryAppId`).
+ * @property lastGovernancePeriod - the last fully processed governance period
+ * @property lastCacheRound - last round at which a successful write-cache call was made
+ * @property updatedAt - ISO timestamp of last update
+ */
+export interface RunnerState {
+  lastGovernancePeriod: GovernancePeriod;
+  lastCacheRound: number;
+  updatedAt: string;
 }
 
 function stateFilePath(stateDir: string, genesisHash: string, registryAppId: number): string {

--- a/packages/runner/src/utils.ts
+++ b/packages/runner/src/utils.ts
@@ -4,15 +4,15 @@ export const BLOCK_TOLERANCE_FOR_1M = 900; // 42m at 2.8s per block
  * Returns true if a 100K block boundary was crossed in the [from, to] interval.
  */
 export function crossed100KBoundary(from: number, to: number): boolean {
-  if (from < to) return Math.floor(to / 1e5) > Math.floor((from - 1) / 1e5);
+  if (from < to) return Math.floor(to / 100_000) > Math.floor((from - 1) / 100_000);
   throw new Error(`Invalid arguments: from (${from}) must be less than to (${to})`);
 }
 
 /**
- * Returns the next 1M boundary (% 1e6) after `round`.
+ * Returns the next 1M boundary (% 1_000_000) after `round`.
  */
 export function next1MBoundary(round: number): number {
-  return Math.ceil((round + 1) / 1e6) * 1e6;
+  return Math.ceil((round + 1) / 1_000_000) * 1_000_000;
 }
 
 /**

--- a/packages/runner/src/utils.ts
+++ b/packages/runner/src/utils.ts
@@ -1,11 +1,10 @@
-export const BLOCK_CACHE_INTERVAL = 100_000;
 export const BLOCK_TOLERANCE_FOR_1M = 900; // 42m at 2.8s per block
 
 /**
  * Returns true if a 100K block boundary was crossed in the [from, to] interval.
  */
 export function crossed100KBoundary(from: number, to: number): boolean {
-  if (from < to) return Math.floor(to / BLOCK_CACHE_INTERVAL) > Math.floor((from - 1) / BLOCK_CACHE_INTERVAL);
+  if (from < to) return Math.floor(to / 1e5) > Math.floor((from - 1) / 1e5);
   throw new Error(`Invalid arguments: from (${from}) must be less than to (${to})`);
 }
 

--- a/packages/runner/test/Dockerfile
+++ b/packages/runner/test/Dockerfile
@@ -41,14 +41,10 @@ RUN printf 'SLACK_BOT_TOKEN=xoxb-test\nSLACK_CHANNEL_ID=C0TEST\n' > /opt/xgov-co
 RUN chown -R root:xgov-committees-runner /opt/xgov-committees \
  && chmod -R u=rwX,g=rX,o= /opt/xgov-committees
 
-# Seed the state directory so the runner finds existing state on first boot.
-# lastProcessedRound is intentionally 0 to guarantee a 100K boundary is crossed on the first run.
+# State directory (state is seeded at run time by seed-state.ts, not at build time,
+# because it must be close to the current chain tip).
 RUN mkdir -p /var/lib/xgov-committees-runner \
- && chown xgov-committees-runner /var/lib/xgov-committees-runner \
- && printf '{"lastProcessedRound":0,"updatedAt":"2024-01-01T00:00:00.000Z"}\n' \
-    > '/var/lib/xgov-committees-runner/wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8_-3147789458.json' \
- && chown xgov-committees-runner \
-    '/var/lib/xgov-committees-runner/wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8_-3147789458.json'
+ && chown xgov-committees-runner:xgov-committees-runner /var/lib/xgov-committees-runner
 
 RUN cp systemd/runner.service /etc/systemd/system/ \
  && cp systemd/runner.timer /etc/systemd/system/

--- a/packages/runner/test/fixtures/seed-state.ts
+++ b/packages/runner/test/fixtures/seed-state.ts
@@ -19,23 +19,25 @@ const url = `${ALGOD_SERVER}:${ALGOD_PORT}/v2/transactions/params`;
 const resp = await fetch(url);
 if (!resp.ok) throw new Error(`seed-state: ${resp.status} ${resp.statusText} from ${url}`);
 const { "last-round": lastRound } = (await resp.json()) as { "last-round": number };
-const lastBf = Math.floor(lastRound / 1e6) * 1e6;
+const lastPeriodEnd = Math.floor(lastRound / 1e6) * 1e6;
 
 if (catchUp) {
   // Two periods behind the current chain tip - enough to trigger catch-up and spawn the generator.
-  const Bf = lastBf - 2e6;
-  const Bi = Bf - COMMITTEE_SELECTION_RANGE;
+  const endRound = lastPeriodEnd - 2e6;
+  const startRound = endRound - COMMITTEE_SELECTION_RANGE;
   saveState(STATE_DIR, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-    lastGovernancePeriod: { Bi, Bf },
-    lastCacheRound: Bf,
+    lastGovernancePeriod: { startRound, endRound },
+    lastCacheRound: endRound,
     updatedAt: new Date().toISOString(),
   });
-  console.log(`Seeded catch-up state: (${Bi}, ${Bf}), lastCacheRound=${Bf}`);
+  console.log(`Seeded catch-up state: (${startRound}, ${endRound}), lastCacheRound=${endRound}`);
 } else {
   saveState(STATE_DIR, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-    lastGovernancePeriod: { Bi: lastBf - COMMITTEE_SELECTION_RANGE, Bf: lastBf },
+    lastGovernancePeriod: { startRound: lastPeriodEnd - COMMITTEE_SELECTION_RANGE, endRound: lastPeriodEnd },
     lastCacheRound: lastRound - 2,
     updatedAt: new Date().toISOString(),
   });
-  console.log(`Seeded state: (${lastBf - COMMITTEE_SELECTION_RANGE}, ${lastBf}), lastCacheRound=${lastRound - 2}`);
+  console.log(
+    `Seeded state: (${lastPeriodEnd - COMMITTEE_SELECTION_RANGE}, ${lastPeriodEnd}), lastCacheRound=${lastRound - 2}`,
+  );
 }

--- a/packages/runner/test/fixtures/seed-state.ts
+++ b/packages/runner/test/fixtures/seed-state.ts
@@ -1,0 +1,39 @@
+/**
+ * Seeds a runner state file. Used by systemd tests where the goal is to test
+ * the systemd lifecycle, not the service logic.
+ *
+ * Usage:
+ *   node --import tsx/esm seed-state.ts             # recent state (no catch-up, quick exit)
+ *   node --import tsx/esm seed-state.ts --catch-up  # stale state (triggers catch-up)
+ */
+import { saveState, COMMITTEE_SELECTION_RANGE } from "../../src/state.ts";
+
+const MAINNET_GENESIS_HASH = "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=";
+const REGISTRY_APP_ID = 3147789458;
+const STATE_DIR = process.env.STATE_DIR ?? "/var/lib/xgov-committees-runner";
+const ALGOD_SERVER = process.env.ALGOD_SERVER ?? "https://mainnet-api.4160.nodely.dev";
+const ALGOD_PORT = process.env.ALGOD_PORT ?? "443";
+const catchUp = process.argv.includes("--catch-up");
+
+const resp = await fetch(`${ALGOD_SERVER}:${ALGOD_PORT}/v2/transactions/params`);
+const { "last-round": lastRound } = (await resp.json()) as { "last-round": number };
+const lastBf = Math.floor(lastRound / 1e6) * 1e6;
+
+if (catchUp) {
+  // Two periods behind the current chain tip - enough to trigger catch-up and spawn the generator.
+  const Bf = lastBf - 2e6;
+  const Bi = Bf - COMMITTEE_SELECTION_RANGE;
+  saveState(STATE_DIR, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
+    lastGovernancePeriod: { Bi, Bf },
+    lastCacheRound: Bf,
+    updatedAt: new Date().toISOString(),
+  });
+  console.log(`Seeded catch-up state: (${Bi}, ${Bf}), lastCacheRound=${Bf}`);
+} else {
+  saveState(STATE_DIR, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
+    lastGovernancePeriod: { Bi: lastBf - COMMITTEE_SELECTION_RANGE, Bf: lastBf },
+    lastCacheRound: lastRound - 2,
+    updatedAt: new Date().toISOString(),
+  });
+  console.log(`Seeded state: (${lastBf - COMMITTEE_SELECTION_RANGE}, ${lastBf}), lastCacheRound=${lastRound - 2}`);
+}

--- a/packages/runner/test/fixtures/seed-state.ts
+++ b/packages/runner/test/fixtures/seed-state.ts
@@ -15,7 +15,9 @@ const ALGOD_SERVER = process.env.ALGOD_SERVER ?? "https://mainnet-api.4160.nodel
 const ALGOD_PORT = process.env.ALGOD_PORT ?? "443";
 const catchUp = process.argv.includes("--catch-up");
 
-const resp = await fetch(`${ALGOD_SERVER}:${ALGOD_PORT}/v2/transactions/params`);
+const url = `${ALGOD_SERVER}:${ALGOD_PORT}/v2/transactions/params`;
+const resp = await fetch(url);
+if (!resp.ok) throw new Error(`seed-state: ${resp.status} ${resp.statusText} from ${url}`);
 const { "last-round": lastRound } = (await resp.json()) as { "last-round": number };
 const lastBf = Math.floor(lastRound / 1e6) * 1e6;
 

--- a/packages/runner/test/integration/integration.test.ts
+++ b/packages/runner/test/integration/integration.test.ts
@@ -38,9 +38,9 @@ describe("runner", () => {
     currentRound = lastRound;
     // Set seed cache round close to and lower than chain tip:
     // We want to test the "no boundary crossed" logic in a realistic scenario.
-    const lastBf = Math.floor(lastRound / 1e6) * 1e6;
+    const lastPeriodEnd = Math.floor(lastRound / 1e6) * 1e6;
     saveState(stateDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-      lastGovernancePeriod: { Bi: lastBf - COMMITTEE_SELECTION_RANGE, Bf: lastBf },
+      lastGovernancePeriod: { startRound: lastPeriodEnd - COMMITTEE_SELECTION_RANGE, endRound: lastPeriodEnd },
       lastCacheRound: lastRound - 2,
       updatedAt: new Date().toISOString(),
     });
@@ -73,11 +73,11 @@ describe("runner", () => {
 
   function seedStaleState() {
     // Two periods behind current tip — triggers catch-up to spawn the generator.
-    const lastBf = Math.floor(currentRound / 1e6) * 1e6;
-    const staleBf = lastBf - 2e6;
+    const lastPeriodEnd = Math.floor(currentRound / 1e6) * 1e6;
+    const stalePeriodEnd = lastPeriodEnd - 2e6;
     saveState(stateDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-      lastGovernancePeriod: { Bi: staleBf - COMMITTEE_SELECTION_RANGE, Bf: staleBf },
-      lastCacheRound: staleBf,
+      lastGovernancePeriod: { startRound: stalePeriodEnd - COMMITTEE_SELECTION_RANGE, endRound: stalePeriodEnd },
+      lastCacheRound: stalePeriodEnd,
       updatedAt: new Date().toISOString(),
     });
   }
@@ -130,7 +130,7 @@ describe("runner", () => {
       expect(stateFiles).toHaveLength(1);
       const state = JSON.parse(readFileSync(join(freshDir, stateFiles[0]), "utf8"));
       expect(state.lastGovernancePeriod).toBeDefined();
-      expect(state.lastGovernancePeriod.Bi).toBeLessThan(state.lastGovernancePeriod.Bf);
+      expect(state.lastGovernancePeriod.startRound).toBeLessThan(state.lastGovernancePeriod.endRound);
     } finally {
       rmSync(freshDir, { recursive: true, force: true });
     }
@@ -140,11 +140,11 @@ describe("runner", () => {
     // Seed state far behind current round — runner should process multiple catch-up periods
     const catchupDir = mkdtempSync(join(tmpdir(), "runner-catchup-"));
     try {
-      const lastBf = Math.floor(currentRound / 1e6) * 1e6;
-      const staleBf = lastBf - 2e6;
+      const lastPeriodEnd = Math.floor(currentRound / 1e6) * 1e6;
+      const stalePeriodEnd = lastPeriodEnd - 2e6;
       saveState(catchupDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-        lastGovernancePeriod: { Bi: staleBf - COMMITTEE_SELECTION_RANGE, Bf: staleBf },
-        lastCacheRound: staleBf,
+        lastGovernancePeriod: { startRound: stalePeriodEnd - COMMITTEE_SELECTION_RANGE, endRound: stalePeriodEnd },
+        lastCacheRound: stalePeriodEnd,
         updatedAt: new Date().toISOString(),
       });
       const result = runRunner({
@@ -159,9 +159,9 @@ describe("runner", () => {
       // Final state should have advanced past the stale period
       const stateFiles = readdirSync(catchupDir).filter((f) => f.endsWith(".json"));
       const state = JSON.parse(readFileSync(join(catchupDir, stateFiles[0]), "utf8"));
-      expect(state.lastGovernancePeriod.Bf).toBeGreaterThan(staleBf);
+      expect(state.lastGovernancePeriod.endRound).toBeGreaterThan(stalePeriodEnd);
       // lastCacheRound should be at least as recent as the end of the final governance period
-      expect(state.lastCacheRound).toBeGreaterThanOrEqual(state.lastGovernancePeriod.Bf);
+      expect(state.lastCacheRound).toBeGreaterThanOrEqual(state.lastGovernancePeriod.endRound);
     } finally {
       rmSync(catchupDir, { recursive: true, force: true });
     }

--- a/packages/runner/test/integration/integration.test.ts
+++ b/packages/runner/test/integration/integration.test.ts
@@ -111,7 +111,7 @@ describe("runner", () => {
     });
   }
 
-  it("bootstraps state from registry creation round when no state file exists", () => {
+  it("bootstraps state from registry creation round when no state file exists", { timeout: 60_000 }, () => {
     const freshDir = mkdtempSync(join(tmpdir(), "runner-bootstrap-"));
     try {
       const result = runRunner({
@@ -131,7 +131,7 @@ describe("runner", () => {
     }
   });
 
-  it("catches up across multiple periods from stale state", () => {
+  it("catches up across multiple periods from stale state", { timeout: 60_000 }, () => {
     // Seed state far behind current round — runner should process multiple catch-up periods
     const catchupDir = mkdtempSync(join(tmpdir(), "runner-catchup-"));
     try {
@@ -153,8 +153,8 @@ describe("runner", () => {
       const stateFiles = readdirSync(catchupDir).filter((f) => f.endsWith(".json"));
       const state = JSON.parse(readFileSync(join(catchupDir, stateFiles[0]), "utf8"));
       expect(state.lastGovernancePeriod.Bf).toBeGreaterThan(52e6);
-      // lastCacheRound should be recent (warming ran after catch-up, not stuck at a stale Bf)
-      expect(state.lastCacheRound).toBeGreaterThan(state.lastGovernancePeriod.Bf);
+      // lastCacheRound should be at least as recent as the end of the final governance period
+      expect(state.lastCacheRound).toBeGreaterThanOrEqual(state.lastGovernancePeriod.Bf);
     } finally {
       rmSync(catchupDir, { recursive: true, force: true });
     }

--- a/packages/runner/test/integration/integration.test.ts
+++ b/packages/runner/test/integration/integration.test.ts
@@ -3,11 +3,10 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, chmodSyn
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { saveState } from "../../src/state.ts";
+import { saveState, INITIAL_PERIOD, COMMITTEE_SELECTION_RANGE } from "../../src/state.ts";
 
 const MAINNET_GENESIS_HASH = "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=";
 const REGISTRY_APP_ID = 3147789458;
-const FIRST_SYNC_ROUND = 50_000_000;
 const FIXTURES = join(import.meta.dirname, "../fixtures");
 const RUNNER_ROOT = join(import.meta.dirname, "../..");
 
@@ -36,8 +35,10 @@ describe("runner", () => {
     }
     const { "last-round": lastRound } = (await resp.json()) as { "last-round": number };
     // Seed 2 blocks behind tip so tests with no boundary crossed exit cleanly.
+    const lastBf = Math.floor(lastRound / 1e6) * 1e6;
     saveState(stateDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-      lastProcessedRound: lastRound - 2,
+      lastGovernancePeriod: { Bi: lastBf - COMMITTEE_SELECTION_RANGE, Bf: lastBf },
+      lastCacheRound: lastRound - 2,
       updatedAt: new Date().toISOString(),
     });
   });
@@ -69,7 +70,8 @@ describe("runner", () => {
 
   function seedStaleState() {
     saveState(stateDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-      lastProcessedRound: 0,
+      lastGovernancePeriod: { Bi: 49e6, Bf: 52e6 },
+      lastCacheRound: 0,
       updatedAt: new Date().toISOString(),
     });
   }
@@ -117,13 +119,44 @@ describe("runner", () => {
         COMMITTEE_GENERATOR_PATH: join(FIXTURES, "generator-instant-exit.js"),
       });
       expect(result.status).toBe(0);
-      expect(result.stdout).toContain(`bootstrapping from round ${FIRST_SYNC_ROUND}`);
+      expect(result.stdout).toContain("bootstrapping from first governance period");
       const stateFiles = readdirSync(freshDir).filter((f) => f.endsWith(".json"));
       expect(stateFiles).toHaveLength(1);
       const state = JSON.parse(readFileSync(join(freshDir, stateFiles[0]), "utf8"));
-      expect(state.lastProcessedRound).toBeGreaterThan(0);
+      expect(state.lastGovernancePeriod).toBeDefined();
+      expect(state.lastGovernancePeriod.Bi).toBe(INITIAL_PERIOD.Bi);
+      expect(state.lastGovernancePeriod.Bi).toBeLessThan(state.lastGovernancePeriod.Bf);
     } finally {
       rmSync(freshDir, { recursive: true, force: true });
+    }
+  });
+
+  it("catches up across multiple periods from stale state", () => {
+    // Seed state far behind current round — runner should process multiple catch-up periods
+    const catchupDir = mkdtempSync(join(tmpdir(), "runner-catchup-"));
+    try {
+      saveState(catchupDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
+        lastGovernancePeriod: { Bi: 49e6, Bf: 52e6 },
+        lastCacheRound: 0,
+        updatedAt: new Date().toISOString(),
+      });
+      const result = runRunner({
+        ...baseEnv(),
+        STATE_DIR: catchupDir,
+        COMMITTEE_GENERATOR_PATH: join(FIXTURES, "generator-instant-exit.js"),
+      });
+      expect(result.status).toBe(0);
+      // Should have processed multiple periods via catch-up
+      const matches = (result.stdout.match(/catch-up/g) || []).length;
+      expect(matches).toBeGreaterThanOrEqual(2);
+      // Final state should have advanced past the stale period
+      const stateFiles = readdirSync(catchupDir).filter((f) => f.endsWith(".json"));
+      const state = JSON.parse(readFileSync(join(catchupDir, stateFiles[0]), "utf8"));
+      expect(state.lastGovernancePeriod.Bf).toBeGreaterThan(52e6);
+      // lastCacheRound should be recent (warming ran after catch-up, not stuck at a stale Bf)
+      expect(state.lastCacheRound).toBeGreaterThan(state.lastGovernancePeriod.Bf);
+    } finally {
+      rmSync(catchupDir, { recursive: true, force: true });
     }
   });
 
@@ -151,8 +184,13 @@ describe("runner", () => {
       COMMITTEE_GENERATOR_PATH: join(FIXTURES, "generator-fatal.js"),
     });
     expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
     expect(result.stdout).toContain("run() failed");
     expect(result.stdout).toContain("fatal error");
+    // State should not have been updated (generator failed before saveState)
+    const stateFiles = readdirSync(stateDir).filter((f) => f.endsWith(".json"));
+    const state = JSON.parse(readFileSync(join(stateDir, stateFiles[0]), "utf8"));
+    expect(state.lastCacheRound).toBe(0);
   });
 
   it("escalates to SIGKILL after grace period when generator ignores SIGTERM", { timeout: 50_000 }, async () => {

--- a/packages/runner/test/integration/integration.test.ts
+++ b/packages/runner/test/integration/integration.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, chmodSyn
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { saveState, INITIAL_PERIOD, COMMITTEE_SELECTION_RANGE } from "../../src/state.ts";
+import { saveState, COMMITTEE_SELECTION_RANGE } from "../../src/state.ts";
 
 const MAINNET_GENESIS_HASH = "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=";
 const REGISTRY_APP_ID = 3147789458;
@@ -34,7 +34,8 @@ describe("runner", () => {
       clearTimeout(timer);
     }
     const { "last-round": lastRound } = (await resp.json()) as { "last-round": number };
-    // Seed 2 blocks behind tip so tests with no boundary crossed exit cleanly.
+    // Set seed cache round close to and lower than chain tip:
+    // We want to test the "no boundary crossed" logic in a realistic scenario.
     const lastBf = Math.floor(lastRound / 1e6) * 1e6;
     saveState(stateDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
       lastGovernancePeriod: { Bi: lastBf - COMMITTEE_SELECTION_RANGE, Bf: lastBf },
@@ -124,7 +125,6 @@ describe("runner", () => {
       expect(stateFiles).toHaveLength(1);
       const state = JSON.parse(readFileSync(join(freshDir, stateFiles[0]), "utf8"));
       expect(state.lastGovernancePeriod).toBeDefined();
-      expect(state.lastGovernancePeriod.Bi).toBe(INITIAL_PERIOD.Bi);
       expect(state.lastGovernancePeriod.Bi).toBeLessThan(state.lastGovernancePeriod.Bf);
     } finally {
       rmSync(freshDir, { recursive: true, force: true });

--- a/packages/runner/test/integration/integration.test.ts
+++ b/packages/runner/test/integration/integration.test.ts
@@ -13,6 +13,7 @@ const RUNNER_ROOT = join(import.meta.dirname, "../..");
 describe("runner", () => {
   let fakeBinDir: string; // holds systemd-notify stub, added to PATH
   let stateDir: string;
+  let currentRound: number;
 
   beforeAll(async () => {
     fakeBinDir = mkdtempSync(join(tmpdir(), "fake-bin-"));
@@ -34,6 +35,7 @@ describe("runner", () => {
       clearTimeout(timer);
     }
     const { "last-round": lastRound } = (await resp.json()) as { "last-round": number };
+    currentRound = lastRound;
     // Set seed cache round close to and lower than chain tip:
     // We want to test the "no boundary crossed" logic in a realistic scenario.
     const lastBf = Math.floor(lastRound / 1e6) * 1e6;
@@ -70,9 +72,12 @@ describe("runner", () => {
   }
 
   function seedStaleState() {
+    // Two periods behind current tip — triggers catch-up to spawn the generator.
+    const lastBf = Math.floor(currentRound / 1e6) * 1e6;
+    const staleBf = lastBf - 2e6;
     saveState(stateDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-      lastGovernancePeriod: { Bi: 49e6, Bf: 52e6 },
-      lastCacheRound: 0,
+      lastGovernancePeriod: { Bi: staleBf - COMMITTEE_SELECTION_RANGE, Bf: staleBf },
+      lastCacheRound: staleBf,
       updatedAt: new Date().toISOString(),
     });
   }
@@ -135,9 +140,11 @@ describe("runner", () => {
     // Seed state far behind current round — runner should process multiple catch-up periods
     const catchupDir = mkdtempSync(join(tmpdir(), "runner-catchup-"));
     try {
+      const lastBf = Math.floor(currentRound / 1e6) * 1e6;
+      const staleBf = lastBf - 2e6;
       saveState(catchupDir, MAINNET_GENESIS_HASH, REGISTRY_APP_ID, {
-        lastGovernancePeriod: { Bi: 49e6, Bf: 52e6 },
-        lastCacheRound: 0,
+        lastGovernancePeriod: { Bi: staleBf - COMMITTEE_SELECTION_RANGE, Bf: staleBf },
+        lastCacheRound: staleBf,
         updatedAt: new Date().toISOString(),
       });
       const result = runRunner({
@@ -152,7 +159,7 @@ describe("runner", () => {
       // Final state should have advanced past the stale period
       const stateFiles = readdirSync(catchupDir).filter((f) => f.endsWith(".json"));
       const state = JSON.parse(readFileSync(join(catchupDir, stateFiles[0]), "utf8"));
-      expect(state.lastGovernancePeriod.Bf).toBeGreaterThan(52e6);
+      expect(state.lastGovernancePeriod.Bf).toBeGreaterThan(staleBf);
       // lastCacheRound should be at least as recent as the end of the final governance period
       expect(state.lastCacheRound).toBeGreaterThanOrEqual(state.lastGovernancePeriod.Bf);
     } finally {
@@ -179,6 +186,8 @@ describe("runner", () => {
 
   it("exits with code 1 when generator fails with a fatal error", () => {
     seedStaleState();
+    const stateFiles = readdirSync(stateDir).filter((f) => f.endsWith(".json"));
+    const stateBefore = JSON.parse(readFileSync(join(stateDir, stateFiles[0]), "utf8"));
     const result = runRunner({
       ...baseEnv(),
       COMMITTEE_GENERATOR_PATH: join(FIXTURES, "generator-fatal.js"),
@@ -188,9 +197,8 @@ describe("runner", () => {
     expect(result.stdout).toContain("run() failed");
     expect(result.stdout).toContain("fatal error");
     // State should not have been updated (generator failed before saveState)
-    const stateFiles = readdirSync(stateDir).filter((f) => f.endsWith(".json"));
-    const state = JSON.parse(readFileSync(join(stateDir, stateFiles[0]), "utf8"));
-    expect(state.lastCacheRound).toBe(0);
+    const stateAfter = JSON.parse(readFileSync(join(stateDir, stateFiles[0]), "utf8"));
+    expect(stateAfter.lastCacheRound).toBe(stateBefore.lastCacheRound);
   });
 
   it("escalates to SIGKILL after grace period when generator ignores SIGTERM", { timeout: 50_000 }, async () => {

--- a/packages/runner/test/systemd/run-test-container.sh
+++ b/packages/runner/test/systemd/run-test-container.sh
@@ -118,7 +118,7 @@ case "$TEST_SCENARIO" in
   boot)
     seed_state
     exec_container systemctl start runner.timer
-    wait_for Result "success|failed" 30
+    sleep 5
     assert_result
     assert_log "Runner started successfully"
     echo "Boot test passed."

--- a/packages/runner/test/systemd/run-test-container.sh
+++ b/packages/runner/test/systemd/run-test-container.sh
@@ -17,6 +17,13 @@ CONTAINER="xgov-runner-systemd-test-$$"
 
 exec_container() { docker exec "$CONTAINER" "$@"; }
 
+# Seeds a state file inside the container. Pass --catch-up for catch-up scenarios.
+seed_state() {
+  exec_container node --import tsx/esm \
+    /opt/xgov-committees/packages/runner/test/fixtures/seed-state.ts "$@"
+  exec_container chown -R xgov-committees-runner:xgov-committees-runner /var/lib/xgov-committees-runner
+}
+
 # Poll a systemd property until it matches one of the expected values.
 # Usage: wait_for PROPERTY "val1|val2" [TIMEOUT=30]
 wait_for() {
@@ -109,6 +116,7 @@ case "$TEST_SCENARIO" in
     ;;
 
   boot)
+    seed_state
     exec_container systemctl start runner.timer
     wait_for Result "success|failed" 30
     assert_result
@@ -117,6 +125,7 @@ case "$TEST_SCENARIO" in
     ;;
 
   stop)
+    seed_state --catch-up
     # Override generator with the long-running graceful-exit fixture.
     exec_container mkdir -p /etc/systemd/system/runner.service.d
     exec_container sh -c \
@@ -133,6 +142,7 @@ case "$TEST_SCENARIO" in
     ;;
 
   failure)
+    seed_state --catch-up
     # Override generator with the fatal fixture to force the service to fail.
     exec_container mkdir -p /etc/systemd/system/runner.service.d
     # Write Slack credentials into a secondary env file if provided by the caller.

--- a/packages/runner/test/unit/service.test.ts
+++ b/packages/runner/test/unit/service.test.ts
@@ -293,9 +293,9 @@ describe("run", () => {
     };
   }
 
-  // All tests use lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 } as base state.
-  function makeState(lastCacheRound: number, Bi = 50e6, Bf = 53e6) {
-    return { lastGovernancePeriod: { Bi, Bf }, lastCacheRound, updatedAt: "" };
+  // All tests use lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 } as base state.
+  function makeState(lastCacheRound: number, startRound = 50e6, endRound = 53e6) {
+    return { lastGovernancePeriod: { startRound, endRound }, lastCacheRound, updatedAt: "" };
   }
 
   it("bootstraps from initial governance period when no state file exists", async () => {
@@ -339,7 +339,7 @@ describe("run", () => {
       stateDir,
       MAINNET_GENESIS_HASH,
       999,
-      expect.objectContaining({ lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 }, lastCacheRound: 53e6 }),
+      expect.objectContaining({ lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 }, lastCacheRound: 53e6 }),
     );
     expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("bootstrapping"));
   });
@@ -510,7 +510,7 @@ describe("run", () => {
       stateDir,
       MAINNET_GENESIS_HASH,
       999,
-      expect.objectContaining({ lastGovernancePeriod: { Bi: 51e6, Bf: 54e6 }, lastCacheRound: 54e6 }),
+      expect.objectContaining({ lastGovernancePeriod: { startRound: 51e6, endRound: 54e6 }, lastCacheRound: 54e6 }),
     );
   });
 

--- a/packages/runner/test/unit/service.test.ts
+++ b/packages/runner/test/unit/service.test.ts
@@ -11,7 +11,10 @@ import { waitForBlock, runWriteCache, run, getActiveChild } from "../../src/serv
 
 vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
 vi.mock("node:timers/promises", () => ({ setTimeout: vi.fn().mockResolvedValue(undefined) }));
-vi.mock("../../src/state.ts", () => ({ loadState: vi.fn(), saveState: vi.fn() }));
+vi.mock("../../src/state.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/state.ts")>();
+  return { ...actual, loadState: vi.fn(), saveState: vi.fn() };
+});
 vi.mock("../../src/config.ts", () => ({}));
 vi.mock("@algorandfoundation/algokit-utils", () => ({
   AlgorandClient: { fromConfig: vi.fn() },
@@ -23,8 +26,7 @@ const mockSaveState = vi.mocked(saveState);
 const mockFromConfig = vi.mocked(AlgorandClient.fromConfig);
 
 const MAINNET_GENESIS_HASH = "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=";
-const ROUND_BUFFER = 21;
-const FIRST_SYNC_ROUND = 50_000_000;
+const TIP_BUFFER = 21;
 
 function makeChildProcess(exitCode: number | null = 0, signal: string | null = null) {
   const emitter = new EventEmitter() as ChildProcess;
@@ -133,6 +135,19 @@ describe("runWriteCache", () => {
     expect(mockSpawn).toHaveBeenCalledOnce();
   });
 
+  it("resolves without retrying when retryOnTip is false and generator hits chain tip", async () => {
+    const { child, emitClose } = makeChildProcess(10);
+    mockSpawn.mockImplementation(() => {
+      process.nextTick(emitClose);
+      return child;
+    });
+
+    await runWriteCache(makeAlgorandClient(vi.fn()), "/fake/path/gen.js", 57_996_051, 58_000_042, false);
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("expected for warming"));
+  });
+
   it("retries and resolves when first run hits chain tip and retry succeeds", async () => {
     const { child: child1, emitClose: close1 } = makeChildProcess(10);
     const { child: child2, emitClose: close2 } = makeChildProcess(0);
@@ -158,7 +173,7 @@ describe("runWriteCache", () => {
       ["/fake/path/gen.js", "--mode", "write-cache", "--from-block", "57996051", "--to-block", "58000042"],
       expect.anything(),
     );
-    expect(statusAfterBlock).toHaveBeenCalledWith(58_000_042 + ROUND_BUFFER - 1);
+    expect(statusAfterBlock).toHaveBeenCalledWith(58_000_042 + TIP_BUFFER - 1);
   });
 
   it("rejects when generator hits chain tip on both attempts", async () => {
@@ -278,10 +293,181 @@ describe("run", () => {
     };
   }
 
-  it("does not spawn write-cache when no boundary is crossed", async () => {
-    const { algorand } = makeRunAlgorand(58_000_042n);
+  // All tests use lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 } as base state.
+  function makeState(lastCacheRound: number, Bi = 50e6, Bf = 53e6) {
+    return { lastGovernancePeriod: { Bi, Bf }, lastCacheRound, updatedAt: "" };
+  }
+
+  it("bootstraps from initial governance period when no state file exists", async () => {
+    // null, bootstrap state (49M,52M) => first period (50M,53M)
+    // round 59.1M: catches up through (56M,59M), warms (57M,60M), then guard breaks
+    const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
+    const getTransactionParams = vi.fn().mockReturnValue({
+      do: async () => ({ firstValid: 59_112_478n, genesisHash }),
+    });
+    mockFromConfig.mockReturnValue({
+      client: { algod: { getTransactionParams, statusAfterBlock: vi.fn() } },
+    } as unknown as AlgorandClient);
+    mockLoadState
+      .mockReturnValueOnce(null) // bootstrap
+      .mockReturnValueOnce(makeState(53e6, 50e6, 53e6))
+      .mockReturnValueOnce(makeState(54e6, 51e6, 54e6))
+      .mockReturnValueOnce(makeState(55e6, 52e6, 55e6))
+      .mockReturnValueOnce(makeState(56e6, 53e6, 56e6))
+      .mockReturnValueOnce(makeState(57e6, 54e6, 57e6))
+      .mockReturnValueOnce(makeState(58e6, 55e6, 58e6))
+      .mockReturnValueOnce(makeState(59e6, 56e6, 59e6)) // after last catch-up → warming
+      .mockReturnValueOnce(makeState(59_112_478, 56e6, 59e6)); // after warming → guard breaks
+
+    const { child, emitClose } = makeChildProcess(0);
+    mockSpawn.mockImplementation(() => {
+      process.nextTick(emitClose);
+      return child;
+    });
+
+    await run(makeConfig());
+
+    // first spawn starts from initial period
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      1,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "50000000", "--to-block", "53000000"],
+      expect.anything(),
+    );
+    expect(mockSaveState).toHaveBeenNthCalledWith(
+      1,
+      stateDir,
+      MAINNET_GENESIS_HASH,
+      999,
+      expect.objectContaining({ lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 }, lastCacheRound: 53e6 }),
+    );
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("bootstrapping"));
+  });
+
+  it("catches up across multiple periods from bootstrap, then warms current period", async () => {
+    // null state, current round 56.4M => 4 catch-ups (50M,53M) to (53M,56M) + 100K warming for (54M,57M)
+    const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
+    const getTransactionParams = vi.fn().mockReturnValue({
+      do: async () => ({ firstValid: 56_412_837n, genesisHash }),
+    });
+    mockFromConfig.mockReturnValue({
+      client: { algod: { getTransactionParams, statusAfterBlock: vi.fn() } },
+    } as unknown as AlgorandClient);
+    mockLoadState
+      .mockReturnValueOnce(null) // bootstrap
+      .mockReturnValueOnce(makeState(53e6, 50e6, 53e6))
+      .mockReturnValueOnce(makeState(54e6, 51e6, 54e6))
+      .mockReturnValueOnce(makeState(55e6, 52e6, 55e6))
+      .mockReturnValueOnce(makeState(56e6, 53e6, 56e6)) // after last catch-up
+      .mockReturnValueOnce(makeState(56_412_837, 53e6, 56e6)); // after warming
+
+    const { child, emitClose } = makeChildProcess(0);
+    mockSpawn.mockImplementation(() => {
+      process.nextTick(emitClose);
+      return child;
+    });
+
+    await run(makeConfig());
+
+    // 4 catch-up spawns
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      1,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "50000000", "--to-block", "53000000"],
+      expect.anything(),
+    );
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      2,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "51000000", "--to-block", "54000000"],
+      expect.anything(),
+    );
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      3,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "52000000", "--to-block", "55000000"],
+      expect.anything(),
+    );
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      4,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "53000000", "--to-block", "56000000"],
+      expect.anything(),
+    );
+    // 5th spawn: warming for current period
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      5,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "54000000", "--to-block", "57000000"],
+      expect.anything(),
+    );
+    expect(mockSpawn).toHaveBeenCalledTimes(5);
+    expect(mockSaveState).toHaveBeenCalledTimes(5);
+    expect(mockSaveState).toHaveBeenLastCalledWith(
+      stateDir,
+      MAINNET_GENESIS_HASH,
+      999,
+      expect.objectContaining({ lastCacheRound: 56_412_837 }),
+    );
+  });
+
+  it("catches up from existing state after downtime, then warms current period", async () => {
+    // state at (54M,57M), round 59.1M => 2 catch-ups (55M,58M) (56M,59M) + warming for (57M,60M)
+    const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
+    const getTransactionParams = vi.fn().mockReturnValue({
+      do: async () => ({ firstValid: 59_112_478n, genesisHash }),
+    });
+    mockFromConfig.mockReturnValue({
+      client: { algod: { getTransactionParams, statusAfterBlock: vi.fn() } },
+    } as unknown as AlgorandClient);
+    mockLoadState
+      .mockReturnValueOnce(makeState(57e6, 54e6, 57e6))
+      .mockReturnValueOnce(makeState(58e6, 55e6, 58e6))
+      .mockReturnValueOnce(makeState(59e6, 56e6, 59e6)) // after last catch-up
+      .mockReturnValueOnce(makeState(59_112_478, 56e6, 59e6)); // after warming
+
+    const { child, emitClose } = makeChildProcess(0);
+    mockSpawn.mockImplementation(() => {
+      process.nextTick(emitClose);
+      return child;
+    });
+
+    await run(makeConfig());
+
+    // 2 catch-up spawns
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      1,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "55000000", "--to-block", "58000000"],
+      expect.anything(),
+    );
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      2,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "56000000", "--to-block", "59000000"],
+      expect.anything(),
+    );
+    // 3rd spawn: warming for current period
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      3,
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "57000000", "--to-block", "60000000"],
+      expect.anything(),
+    );
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+    expect(mockSaveState).toHaveBeenCalledTimes(3);
+    expect(mockSaveState).toHaveBeenLastCalledWith(
+      stateDir,
+      MAINNET_GENESIS_HASH,
+      999,
+      expect.objectContaining({ lastCacheRound: 59_112_478 }),
+    );
+  });
+
+  it("no boundary crossed: does not spawn child", async () => {
+    const { algorand } = makeRunAlgorand(53_500_050n);
     mockFromConfig.mockReturnValue(algorand as unknown as AlgorandClient);
-    mockLoadState.mockReturnValue({ lastProcessedRound: 58_000_040, updatedAt: "" });
+    mockLoadState.mockReturnValue(makeState(53_500_042));
 
     await run(makeConfig());
 
@@ -289,21 +475,20 @@ describe("run", () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it("spawns write-cache and re-evaluates when 100K boundary is crossed", async () => {
+  it("close 1M boundary: waits for period end and spawns write-cache", async () => {
     const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
     const getTransactionParams = vi
       .fn()
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 58_000_042n, genesisHash }) })
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 58_000_050n, genesisHash }) });
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_999_150n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_999_150n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 54_000_000n, genesisHash }) });
     const statusAfterBlock = vi.fn().mockReturnValue({
-      do: async () => ({ lastRound: 58_000_200n }),
+      do: async () => ({ lastRound: BigInt(54_000_021) }),
     });
     mockFromConfig.mockReturnValue({
       client: { algod: { getTransactionParams, statusAfterBlock } },
     } as unknown as AlgorandClient);
-    mockLoadState
-      .mockReturnValueOnce({ lastProcessedRound: 57_996_051, updatedAt: "" })
-      .mockReturnValueOnce({ lastProcessedRound: 58_000_042, updatedAt: "" });
+    mockLoadState.mockReturnValueOnce(makeState(53_999_000)).mockReturnValueOnce(makeState(54e6, 51e6, 54e6));
 
     const { child, emitClose } = makeChildProcess(0);
     mockSpawn.mockImplementation(() => {
@@ -316,7 +501,44 @@ describe("run", () => {
     expect(mockSpawn).toHaveBeenCalledOnce();
     expect(mockSpawn).toHaveBeenCalledWith(
       "node",
-      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "57996052", "--to-block", "58000042"],
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "51000000", "--to-block", "54000000"],
+      expect.anything(),
+    );
+    expect(statusAfterBlock).toHaveBeenCalledWith(54_000_020);
+    expect(mockSaveState).toHaveBeenCalledOnce();
+    expect(mockSaveState).toHaveBeenCalledWith(
+      stateDir,
+      MAINNET_GENESIS_HASH,
+      999,
+      expect.objectContaining({ lastGovernancePeriod: { Bi: 51e6, Bf: 54e6 }, lastCacheRound: 54e6 }),
+    );
+  });
+
+  it("100K boundary crossed: spawns write-cache and re-evaluates", async () => {
+    const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
+    const getTransactionParams = vi
+      .fn()
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_050n, genesisHash }) });
+    const statusAfterBlock = vi.fn();
+    mockFromConfig.mockReturnValue({
+      client: { algod: { getTransactionParams, statusAfterBlock } },
+    } as unknown as AlgorandClient);
+    mockLoadState.mockReturnValueOnce(makeState(53_096_000)).mockReturnValueOnce(makeState(53_200_042));
+
+    const { child, emitClose } = makeChildProcess(0);
+    mockSpawn.mockImplementation(() => {
+      process.nextTick(emitClose);
+      return child;
+    });
+
+    await run(makeConfig());
+
+    expect(mockSpawn).toHaveBeenCalledOnce();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "node",
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "51000000", "--to-block", "54000000"],
       expect.anything(),
     );
     expect(mockSaveState).toHaveBeenCalledOnce();
@@ -324,74 +546,32 @@ describe("run", () => {
       stateDir,
       MAINNET_GENESIS_HASH,
       999,
-      expect.objectContaining({ lastProcessedRound: 58_000_042 }),
+      expect.objectContaining({ lastCacheRound: 53_200_042 }),
     );
-    expect(getTransactionParams).toHaveBeenCalledTimes(2);
+    expect(getTransactionParams).toHaveBeenCalledTimes(3);
     expect(mockLoadState).toHaveBeenCalledTimes(2);
     expect(statusAfterBlock).not.toHaveBeenCalled();
     expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("100K boundary crossed"));
   });
 
-  it("waits for 1M boundary and spawns write-cache when close to 1M and no 100K boundary is crossed", async () => {
-    // currentRound=999_950: closeTo1MBoundary=true (50 blocks from 1M), crossed100KBoundary(999_901, 999_950)=false
+  it("100K boundary crossed: re-evaluates and meets close to 1M boundary", async () => {
     const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
     const getTransactionParams = vi
       .fn()
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 999_950n, genesisHash }) })
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 1_000_050n, genesisHash }) });
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_999_150n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 54_000_000n, genesisHash }) });
     const statusAfterBlock = vi.fn().mockReturnValue({
-      do: async () => ({ lastRound: BigInt(1_000_021) }),
+      do: async () => ({ lastRound: BigInt(54_000_021) }),
     });
     mockFromConfig.mockReturnValue({
       client: { algod: { getTransactionParams, statusAfterBlock } },
     } as unknown as AlgorandClient);
     mockLoadState
-      .mockReturnValueOnce({ lastProcessedRound: 999_900, updatedAt: "" })
-      .mockReturnValueOnce({ lastProcessedRound: 1_000_000, updatedAt: "" });
-
-    const { child, emitClose } = makeChildProcess(0);
-    mockSpawn.mockImplementation(() => {
-      process.nextTick(emitClose);
-      return child;
-    });
-
-    await run(makeConfig());
-
-    expect(mockSpawn).toHaveBeenCalledOnce();
-    expect(mockSpawn).toHaveBeenCalledWith(
-      "node",
-      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "999901", "--to-block", "1000000"],
-      expect.anything(),
-    );
-    expect(statusAfterBlock).toHaveBeenCalledWith(1_000_020);
-    expect(mockSaveState).toHaveBeenCalledOnce();
-    expect(mockSaveState).toHaveBeenCalledWith(
-      stateDir,
-      MAINNET_GENESIS_HASH,
-      999,
-      expect.objectContaining({ lastProcessedRound: 1_000_000 }),
-    );
-  });
-
-  it("spawns 100K write-cache then 1M write-cache when both boundaries are crossed", async () => {
-    // currentRound=999_950, nextRoundToProcess=899_001:
-    //   crossed100KBoundary(899_001, 999_950)=true (900K boundary in range)
-    //   closeTo1MBoundary(999_950)=true (50 blocks from 1M)
-    //   => 1M write-cache from = currentRound + 1 = 999_951
-    const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
-    const getTransactionParams = vi
-      .fn()
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 999_950n, genesisHash }) })
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 1_000_050n, genesisHash }) });
-    const statusAfterBlock = vi.fn().mockReturnValue({
-      do: async () => ({ lastRound: BigInt(1_000_021) }),
-    });
-    mockFromConfig.mockReturnValue({
-      client: { algod: { getTransactionParams, statusAfterBlock } },
-    } as unknown as AlgorandClient);
-    mockLoadState
-      .mockReturnValueOnce({ lastProcessedRound: 899_000, updatedAt: "" })
-      .mockReturnValueOnce({ lastProcessedRound: 1_000_000, updatedAt: "" });
+      .mockReturnValueOnce(makeState(53_096_000))
+      .mockReturnValueOnce(makeState(53_200_042))
+      .mockReturnValueOnce(makeState(54e6, 51e6, 54e6));
 
     const { child, emitClose } = makeChildProcess(0);
     mockSpawn.mockImplementation(() => {
@@ -405,29 +585,52 @@ describe("run", () => {
     expect(mockSpawn).toHaveBeenNthCalledWith(
       1,
       "node",
-      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "899001", "--to-block", "999950"],
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "51000000", "--to-block", "54000000"],
       expect.anything(),
     );
     expect(mockSpawn).toHaveBeenNthCalledWith(
       2,
       "node",
-      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "999951", "--to-block", "1000000"],
+      ["/fake/generator.js", "--mode", "write-cache", "--from-block", "51000000", "--to-block", "54000000"],
       expect.anything(),
     );
-    expect(statusAfterBlock).toHaveBeenCalledWith(1_000_020);
-    expect(mockSaveState).toHaveBeenCalledOnce();
+    expect(statusAfterBlock).toHaveBeenCalledWith(54_000_020);
+    expect(mockSaveState).toHaveBeenCalledTimes(2);
+  });
+
+  it("100K boundary crossed: continues without error when generator hits tip", async () => {
+    const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
+    const getTransactionParams = vi
+      .fn()
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_050n, genesisHash }) });
+    mockFromConfig.mockReturnValue({
+      client: { algod: { getTransactionParams, statusAfterBlock: vi.fn() } },
+    } as unknown as AlgorandClient);
+    mockLoadState.mockReturnValueOnce(makeState(53_096_000)).mockReturnValueOnce(makeState(53_200_042));
+
+    const { child, emitClose } = makeChildProcess(10); // tip
+    mockSpawn.mockImplementation(() => {
+      process.nextTick(emitClose);
+      return child;
+    });
+
+    await expect(run(makeConfig())).resolves.toBeUndefined();
+    expect(mockSpawn).toHaveBeenCalledOnce(); // no retry
+    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining("expected for warming"));
     expect(mockSaveState).toHaveBeenCalledWith(
       stateDir,
       MAINNET_GENESIS_HASH,
       999,
-      expect.objectContaining({ lastProcessedRound: 1_000_000 }),
+      expect.objectContaining({ lastCacheRound: 53_200_042 }),
     );
   });
 
   it("throws when generator exits with fatal error", async () => {
-    const { algorand } = makeRunAlgorand(58_000_042n);
+    const { algorand } = makeRunAlgorand(55_000_000n);
     mockFromConfig.mockReturnValue(algorand as unknown as AlgorandClient);
-    mockLoadState.mockReturnValue({ lastProcessedRound: 0, updatedAt: "" });
+    mockLoadState.mockReturnValue(makeState(53e6));
 
     const { child, emitClose } = makeChildProcess(1);
     mockSpawn.mockImplementation(() => {
@@ -439,17 +642,12 @@ describe("run", () => {
   });
 
   it("throws when generator hits chain tip on both attempts", async () => {
-    const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
-    const getTransactionParams = vi.fn().mockReturnValue({
-      do: async () => ({ firstValid: 58_000_042n, genesisHash }),
+    const { algorand, statusAfterBlock } = makeRunAlgorand(55_000_000n);
+    statusAfterBlock.mockReturnValue({
+      do: async () => ({ lastRound: BigInt(55_000_100) }),
     });
-    const statusAfterBlock = vi.fn().mockReturnValue({
-      do: async () => ({ lastRound: 58_000_200n }),
-    });
-    mockFromConfig.mockReturnValue({
-      client: { algod: { getTransactionParams, statusAfterBlock } },
-    } as unknown as AlgorandClient);
-    mockLoadState.mockReturnValue({ lastProcessedRound: 57_996_051, updatedAt: "" });
+    mockFromConfig.mockReturnValue(algorand as unknown as AlgorandClient);
+    mockLoadState.mockReturnValue(makeState(53e6));
 
     const { child: child1, emitClose: close1 } = makeChildProcess(10);
     const { child: child2, emitClose: close2 } = makeChildProcess(10);
@@ -466,66 +664,25 @@ describe("run", () => {
     await expect(run(makeConfig())).rejects.toThrow("generator reached chain tip even after retrying");
   });
 
-  it("bootstraps from FIRST_SYNC_ROUND when no state file exists", async () => {
-    const { algorand } = makeRunAlgorand(58_000_042n);
+  it("throws on first iteration when algod round is not ahead of the last cache round", async () => {
+    const { algorand } = makeRunAlgorand(53_500_042n);
     mockFromConfig.mockReturnValue(algorand as unknown as AlgorandClient);
-    mockLoadState.mockReturnValueOnce(null).mockReturnValueOnce({ lastProcessedRound: 58_000_042, updatedAt: "" });
+    mockLoadState.mockReturnValue(makeState(53_500_042));
 
-    const { child, emitClose } = makeChildProcess(0);
-    mockSpawn.mockImplementation(() => {
-      process.nextTick(emitClose);
-      return child;
-    });
-
-    await run(makeConfig());
-
-    expect(mockSpawn).toHaveBeenCalledOnce();
-    expect(mockSpawn).toHaveBeenCalledWith(
-      "node",
-      [
-        "/fake/generator.js",
-        "--mode",
-        "write-cache",
-        "--from-block",
-        String(FIRST_SYNC_ROUND),
-        "--to-block",
-        "58000042",
-      ],
-      expect.anything(),
-    );
-    expect(mockSaveState).toHaveBeenCalledOnce();
-    expect(mockSaveState).toHaveBeenCalledWith(
-      stateDir,
-      MAINNET_GENESIS_HASH,
-      999,
-      expect.objectContaining({ lastProcessedRound: 58_000_042 }),
-    );
-    expect(vi.mocked(console.log)).toHaveBeenCalledWith(expect.stringContaining(String(FIRST_SYNC_ROUND)));
+    await expect(run(makeConfig())).rejects.toThrow("not ahead of the last cache");
   });
 
-  it("throws on first iteration when algod round is not ahead of the next round to process", async () => {
-    // currentRound (58_000_040) == nextRoundToProcess (58_000_040)
-    const { algorand } = makeRunAlgorand(58_000_040n);
-    mockFromConfig.mockReturnValue(algorand as unknown as AlgorandClient);
-    mockLoadState.mockReturnValue({ lastProcessedRound: 58_000_039, updatedAt: "" });
-
-    await expect(run(makeConfig())).rejects.toThrow("not ahead of the next round to process");
-  });
-
-  it("exits cleanly on second iteration when algod has not advanced past the last processed round", async () => {
-    // Iteration 1: 100K boundary crossed → write-cache, saveState.
-    // Iteration 2: algod still returns the same round (timer fired before new blocks) → clean break.
+  it("exits cleanly on second iteration when algod has not advanced past the last cache round", async () => {
     const genesisHash = new Uint8Array(Buffer.from(MAINNET_GENESIS_HASH, "base64"));
     const getTransactionParams = vi
       .fn()
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 58_000_042n, genesisHash }) })
-      .mockReturnValueOnce({ do: async () => ({ firstValid: 58_000_042n, genesisHash }) });
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) })
+      .mockReturnValueOnce({ do: async () => ({ firstValid: 53_200_042n, genesisHash }) });
     mockFromConfig.mockReturnValue({
       client: { algod: { getTransactionParams, statusAfterBlock: vi.fn() } },
     } as unknown as AlgorandClient);
-    mockLoadState
-      .mockReturnValueOnce({ lastProcessedRound: 57_996_051, updatedAt: "" })
-      .mockReturnValueOnce({ lastProcessedRound: 58_000_042, updatedAt: "" });
+    mockLoadState.mockReturnValueOnce(makeState(53_096_000)).mockReturnValueOnce(makeState(53_200_042));
 
     const { child, emitClose } = makeChildProcess(0);
     mockSpawn.mockImplementation(() => {

--- a/packages/runner/test/unit/state.test.ts
+++ b/packages/runner/test/unit/state.test.ts
@@ -31,7 +31,7 @@ describe("state", () => {
 
     it("returns the saved state when a file exists", () => {
       const state: RunnerState = {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 53e6,
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
@@ -43,7 +43,7 @@ describe("state", () => {
   describe("saveState", () => {
     it("writes the correct JSON", () => {
       const state: RunnerState = {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 53e6,
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
@@ -53,12 +53,12 @@ describe("state", () => {
 
     it("overwrites an existing state file", () => {
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 53e6,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastGovernancePeriod: { Bi: 51e6, Bf: 54e6 },
+        lastGovernancePeriod: { startRound: 51e6, endRound: 54e6 },
         lastCacheRound: 54e6,
         updatedAt: "2026-01-02T00:00:00.000Z",
       });
@@ -67,7 +67,7 @@ describe("state", () => {
 
     it("does not leave a .tmp file behind", () => {
       const state: RunnerState = {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 53e6,
         updatedAt: "2026-01-01T00:00:00.000Z",
       };
@@ -78,12 +78,12 @@ describe("state", () => {
 
     it("uses separate files for different registry app IDs", () => {
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 100,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
       saveState(stateDir, GENESIS_HASH, 999, {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 200,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
@@ -94,12 +94,12 @@ describe("state", () => {
     it("uses separate files for different genesis hashes", () => {
       const otherGenesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 100,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
       saveState(stateDir, otherGenesisHash, REGISTRY_APP_ID, {
-        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastGovernancePeriod: { startRound: 50e6, endRound: 53e6 },
         lastCacheRound: 200,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });

--- a/packages/runner/test/unit/state.test.ts
+++ b/packages/runner/test/unit/state.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadState, saveState } from "../../src/state.ts";
+import { type RunnerState, loadState, saveState } from "../../src/state.ts";
 
 const GENESIS_HASH = "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=";
 const REGISTRY_APP_ID = 3147789458;
@@ -30,7 +30,11 @@ describe("state", () => {
     });
 
     it("returns the saved state when a file exists", () => {
-      const state = { lastProcessedRound: 58000000, updatedAt: "2026-01-01T00:00:00.000Z" };
+      const state: RunnerState = {
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 53e6,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      };
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, state);
       expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)).toEqual(state);
     });
@@ -38,25 +42,35 @@ describe("state", () => {
 
   describe("saveState", () => {
     it("writes the correct JSON", () => {
-      const state = { lastProcessedRound: 58000000, updatedAt: "2026-01-01T00:00:00.000Z" };
+      const state: RunnerState = {
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 53e6,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      };
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, state);
       expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)).toEqual(state);
     });
 
     it("overwrites an existing state file", () => {
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastProcessedRound: 58000000,
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 53e6,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastProcessedRound: 58100000,
+        lastGovernancePeriod: { Bi: 51e6, Bf: 54e6 },
+        lastCacheRound: 54e6,
         updatedAt: "2026-01-02T00:00:00.000Z",
       });
-      expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)?.lastProcessedRound).toBe(58100000);
+      expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)?.lastCacheRound).toBe(54e6);
     });
 
     it("does not leave a .tmp file behind", () => {
-      const state = { lastProcessedRound: 58000000, updatedAt: "2026-01-01T00:00:00.000Z" };
+      const state: RunnerState = {
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 53e6,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      };
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, state);
       const safeHash = GENESIS_HASH.replace(/[/=]/g, "_");
       expect(existsSync(join(stateDir, `${safeHash}-${REGISTRY_APP_ID}.json.tmp`))).toBe(false);
@@ -64,29 +78,33 @@ describe("state", () => {
 
     it("uses separate files for different registry app IDs", () => {
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastProcessedRound: 100,
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 100,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
       saveState(stateDir, GENESIS_HASH, 999, {
-        lastProcessedRound: 200,
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 200,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
-      expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)?.lastProcessedRound).toBe(100);
-      expect(loadState(stateDir, GENESIS_HASH, 999)?.lastProcessedRound).toBe(200);
+      expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)?.lastCacheRound).toBe(100);
+      expect(loadState(stateDir, GENESIS_HASH, 999)?.lastCacheRound).toBe(200);
     });
 
     it("uses separate files for different genesis hashes", () => {
       const otherGenesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
       saveState(stateDir, GENESIS_HASH, REGISTRY_APP_ID, {
-        lastProcessedRound: 100,
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 100,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
       saveState(stateDir, otherGenesisHash, REGISTRY_APP_ID, {
-        lastProcessedRound: 200,
+        lastGovernancePeriod: { Bi: 50e6, Bf: 53e6 },
+        lastCacheRound: 200,
         updatedAt: "2026-01-01T00:00:00.000Z",
       });
-      expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)?.lastProcessedRound).toBe(100);
-      expect(loadState(stateDir, otherGenesisHash, REGISTRY_APP_ID)?.lastProcessedRound).toBe(200);
+      expect(loadState(stateDir, GENESIS_HASH, REGISTRY_APP_ID)?.lastCacheRound).toBe(100);
+      expect(loadState(stateDir, otherGenesisHash, REGISTRY_APP_ID)?.lastCacheRound).toBe(200);
     });
   });
 });


### PR DESCRIPTION
- Refactor runner state and service loop to use ARC-86 governance periods `(Bi, Bf)` instead of raw round tracking (see #25)                                           
- Update tests to match
- Add readme and contributing (first version, can be revisited)

NOTE: can be merged/fixed as needed.                                                                                                         
                                     