### PR TITLE
chore: fix eslint errors and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
 
       - run: pnpm run format:check
 
-      - run: pnpm --filter xgov-committees-runner run lint # TODO: Replace with `pnpm run lint`
+      - run: pnpm run lint
 
-      - run: pnpm --filter xgov-committees-runner run build # TODO: Replace with `pnpm run build`
+      - run: pnpm run build
 
   test-generator:
     needs: style

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,5 @@
 set -euo pipefail
 
 pnpm run format:check && \
-# TODO: replace with `pnpm run lint`
-pnpm --filter xgov-committees-runner run lint && \
-# TODO: replace with `pnpm run build`
-pnpm --filter xgov-committees-runner run build
+pnpm run lint && \
+pnpm run build

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",
     "clean": "rm -rf packages/*/dist",
-    "lint": "pnpm -r run lint --if-present",
-    "lint:fix": "pnpm -r run lint:fix --if-present",
-    "format": "pnpm -r run format --if-present",
-    "format:check": "pnpm -r run format:check --if-present"
+    "lint": "pnpm -r --if-present run lint",
+    "lint:fix": "pnpm -r --if-present run lint:fix",
+    "format": "pnpm -r --if-present run format",
+    "format:check": "pnpm -r --if-present run format:check"
   },
   "devDependencies": {
     "husky": "^9.1.7",

--- a/packages/committee-generator/src/cache/cache-manager.ts
+++ b/packages/committee-generator/src/cache/cache-manager.ts
@@ -67,35 +67,32 @@ export class CacheManager {
     if (this.loading.has(pageStart)) {
       return this.loading.get(pageStart)!;
     }
-    let q: Promise<CachePage>;
-    this.loading.set(
-      pageStart,
-      (q = new Promise(async (resolve, reject) => {
-        try {
-          if (config.verbose)
-            console.debug(`\nLoading ${pageStart} numPages:${this.numPages} max:${this.maxPages}`);
-          if (this.numPages > this.maxPages) {
-            await this.evictPage();
-          }
-
-          const filename = this.getBlockCacheFilePath(pageStart);
-          let page: CachePage;
-
-          if (this.useS3) {
-            page = await CachePage.loadPageFromS3(pageStart, filename);
-          } else {
-            page = await CachePage.loadPage(filename);
-          }
-
-          this.pages.set(pageStart, page);
-          this.loading.delete(pageStart);
-          resolve(page);
-        } catch (e) {
-          reject(e);
+    const loadPromise = Promise.resolve().then(async () => {
+      try {
+        if (config.verbose)
+          console.debug(`\nLoading ${pageStart} numPages:${this.numPages} max:${this.maxPages}`);
+        if (this.numPages > this.maxPages) {
+          await this.evictPage();
         }
-      })),
-    );
-    return q;
+
+        const filename = this.getBlockCacheFilePath(pageStart);
+        let page: CachePage;
+
+        if (this.useS3) {
+          page = await CachePage.loadPageFromS3(pageStart, filename);
+        } else {
+          page = await CachePage.loadPage(filename);
+        }
+
+        this.pages.set(pageStart, page);
+        return page;
+      } finally {
+        this.loading.delete(pageStart);
+      }
+    });
+
+    this.loading.set(pageStart, loadPromise);
+    return loadPromise;
   }
 
   get oldestPage() {

--- a/packages/committee-generator/src/cache/index.ts
+++ b/packages/committee-generator/src/cache/index.ts
@@ -28,7 +28,7 @@ export const getCachedRounds = async (min: number, max: number): Promise<Set<num
           const data = JSON.parse(buffer.toString());
           const existingRounds = new Set(Object.keys(data).map((s) => parseInt(s, 10)));
           rounds.push(...existingRounds);
-        } catch (e) {
+        } catch {
           // pretend corrupt files do not exist, they will be overwritten anyway
         }
       }),

--- a/packages/committee-generator/src/cache/utils.ts
+++ b/packages/committee-generator/src/cache/utils.ts
@@ -6,7 +6,7 @@ export const getCachePath = (subPath: string): string => {
   const { genesisID, genesisHash } = networkMetadata;
   const networkPath = join(
     config.dataPath,
-    `${genesisID}-${genesisHash.replace(/[\/=]/g, '_')}`,
+    `${genesisID}-${genesisHash.replace(/[/=]/g, '_')}`,
     subPath,
   );
   return networkPath;

--- a/packages/committee-generator/src/committee-validate.ts
+++ b/packages/committee-generator/src/committee-validate.ts
@@ -12,6 +12,7 @@ export function validateCommitteeString(committeeStr: string): Committee {
   try {
     committee = JSON.parse(committeeStr);
   } catch (e) {
+    // eslint-disable-next-line preserve-caught-error
     throw new Error(`Committee JSON was invalid: ${(e as Error).message}`);
   }
 
@@ -42,7 +43,7 @@ export function validateCommitteeString(committeeStr: string): Committee {
   for (const { address, votes } of committee.xGovs) {
     try {
       decodeAddress(address);
-    } catch (e) {
+    } catch {
       throw new Error(`Committee JSON included invalid address: ${address}`);
     }
     if (xGovs.has(address)) {

--- a/packages/committee-generator/src/committee-validate.ts
+++ b/packages/committee-generator/src/committee-validate.ts
@@ -11,9 +11,9 @@ export function validateCommitteeString(committeeStr: string): Committee {
   let committee: Committee;
   try {
     committee = JSON.parse(committeeStr);
-  } catch (e) {
-    // eslint-disable-next-line preserve-caught-error
-    throw new Error(`Committee JSON was invalid: ${(e as Error).message}`);
+  } catch (e: unknown) {
+    const originalMessage = e instanceof Error ? e.message : String(e);
+    throw new Error(`Committee JSON was invalid: ${originalMessage}`, { cause: e });
   }
 
   const validate = new Ajv().compile(committeeSchema);

--- a/packages/committee-generator/src/config.ts
+++ b/packages/committee-generator/src/config.ts
@@ -194,8 +194,7 @@ const parsedArgs = parser.help().parseSync();
 for (const argvConfigEntry of argvConfig) {
   const { name, type } = argvConfigEntry;
   if (type !== 'number') continue;
-  // @ts-ignore - kebab-case property access
-  const value = parsedArgs[name];
+  const value = (parsedArgs as Record<string, unknown>)[name];
   if (isNaN(value as number)) {
     console.error(`Configuration value "${name}" expected a number, found non-numeric value`);
     process.exit(1);

--- a/packages/committee-generator/src/modes/write-cache.ts
+++ b/packages/committee-generator/src/modes/write-cache.ts
@@ -58,6 +58,7 @@ export async function runWriteCache(fromBlock: number, toBlock: number): Promise
   }
 
   const committeeID = getCommitteeID(committee);
+  // @ts-expect-error - At runtime `committeeID` is a string-compatible identifier
   const safeCommitteeID = committeeIdToSafeFileName(committeeID);
   console.log('Safe committee filename:', safeCommitteeID);
   console.log('Committee ID:', committeeID);

--- a/packages/committee-generator/src/modes/write-cache.ts
+++ b/packages/committee-generator/src/modes/write-cache.ts
@@ -58,7 +58,6 @@ export async function runWriteCache(fromBlock: number, toBlock: number): Promise
   }
 
   const committeeID = getCommitteeID(committee);
-  // @ts-expect-error - At runtime `committeeID` is a string-compatible identifier
   const safeCommitteeID = committeeIdToSafeFileName(committeeID);
   console.log('Safe committee filename:', safeCommitteeID);
   console.log('Committee ID:', committeeID);

--- a/packages/committee-generator/src/proposers.ts
+++ b/packages/committee-generator/src/proposers.ts
@@ -27,7 +27,7 @@ const _getBlockProposers = async (rnds: number[]): Promise<ProposerMap> => {
     await pMap(
       chunked,
       async (rnd) => {
-        const { proposer: proposerAddr, round, genesisHash } = await getBlock(rnd);
+        const { proposer: proposerAddr } = await getBlock(rnd);
         const proposer = proposerAddr.toString();
 
         const existingRounds = proposers.get(proposer) ?? [];

--- a/packages/committee-generator/src/s3/index.ts
+++ b/packages/committee-generator/src/s3/index.ts
@@ -219,7 +219,6 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
       }
 
       const committeeID = getCommitteeID(committee);
-      // @ts-expect-error - At runtime `committeeID` is a string-compatible identifier
       const safeCommitteeID = committeeIdToSafeFileName(committeeID);
 
       const endRoundKey = `${baseKey}${toRound}.json`;

--- a/packages/committee-generator/src/s3/index.ts
+++ b/packages/committee-generator/src/s3/index.ts
@@ -6,6 +6,7 @@ import {
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
+  S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { networkMetadata } from '../algod';
 import { config } from '../config';
@@ -30,7 +31,7 @@ export function getS3Client(): S3Client {
   }
 
   if (!s3Client) {
-    const clientConfig: any = {
+    const clientConfig: S3ClientConfig = {
       region: region,
       endpoint: endpoint,
       credentials: {
@@ -512,7 +513,7 @@ export async function uploadData(
 export function getKeyWithNetworkMetadata(keySuffix: string): string {
   const { genesisID, genesisHash } = networkMetadata;
 
-  const networkPrefix = `${genesisID}-${genesisHash.replace(/[\/=]/g, '_')}`;
+  const networkPrefix = `${genesisID}-${genesisHash.replace(/[/=]/g, '_')}`;
 
   return `${networkPrefix}/${keySuffix}`;
 }

--- a/packages/committee-generator/src/s3/index.ts
+++ b/packages/committee-generator/src/s3/index.ts
@@ -219,6 +219,7 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
       }
 
       const committeeID = getCommitteeID(committee);
+      // @ts-expect-error - At runtime `committeeID` is a string-compatible identifier
       const safeCommitteeID = committeeIdToSafeFileName(committeeID);
 
       const endRoundKey = `${baseKey}${toRound}.json`;

--- a/packages/committee-generator/src/shutdown.ts
+++ b/packages/committee-generator/src/shutdown.ts
@@ -170,6 +170,8 @@ export async function awaitShutdown(): Promise<never> {
   }
   // If no shutdown in progress but this was called, initiate graceful shutdown
   // This handles the edge case where ShuttingDownError is thrown but shutdown hasn't started yet
+  // @ts-expect-error - shutdown is inferred as Promise<void>, but awaitShutdown is declared as Promise<never>;
+  // TypeScript reports: "Type 'Promise<void>' is not assignable to type 'Promise<never>'", but at runtime this never resolves.
   return shutdown(ExitCode.SUCCESS, 'expected', 'Awaiting shutdown when no shutdown in progress');
 }
 

--- a/packages/committee-generator/src/shutdown.ts
+++ b/packages/committee-generator/src/shutdown.ts
@@ -117,7 +117,11 @@ async function waitForPendingOperations(timeoutMs = 30000): Promise<void> {
   }
 }
 
-export async function shutdown(exitCode: number, reason: ShutdownReason, message?: string) {
+export async function shutdown(
+  exitCode: number,
+  reason: ShutdownReason,
+  message?: string,
+): Promise<never> {
   if (shutdownPromise) {
     return shutdownPromise;
   }
@@ -125,7 +129,7 @@ export async function shutdown(exitCode: number, reason: ShutdownReason, message
   if (!shuttingDown) {
     shuttingDown = true;
 
-    shutdownPromise = (async () => {
+    shutdownPromise = (async (): Promise<never> => {
       console.log(`Shutdown initiated (${reason})`, message ?? '');
 
       try {
@@ -149,6 +153,11 @@ export async function shutdown(exitCode: number, reason: ShutdownReason, message
     })();
   }
 
+  if (!shutdownPromise) {
+    // This should be unreachable; added to satisfy the type system without using a non-null assertion.
+    throw new Error('Shutdown promise was not initialized');
+  }
+
   return shutdownPromise;
 }
 
@@ -170,8 +179,6 @@ export async function awaitShutdown(): Promise<never> {
   }
   // If no shutdown in progress but this was called, initiate graceful shutdown
   // This handles the edge case where ShuttingDownError is thrown but shutdown hasn't started yet
-  // @ts-expect-error - shutdown is inferred as Promise<void>, but awaitShutdown is declared as Promise<never>;
-  // TypeScript reports: "Type 'Promise<void>' is not assignable to type 'Promise<never>'", but at runtime this never resolves.
   return shutdown(ExitCode.SUCCESS, 'expected', 'Awaiting shutdown when no shutdown in progress');
 }
 

--- a/packages/committee-generator/src/utils.ts
+++ b/packages/committee-generator/src/utils.ts
@@ -62,9 +62,9 @@ export function sha512_256_raw(input: string | Buffer) {
   return Buffer.from(sha512_256(input), 'hex');
 }
 
-export function committeeIdToSafeFileName(committeeId: Buffer): string {
-  // Use base64url encoding (base64 without padding, using URL-safe characters)
-  return committeeId.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+export function committeeIdToSafeFileName(committeeIdBase64: string): string {
+  // Convert base64 to base64url (URL-safe characters and no padding)
+  return committeeIdBase64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 export async function walkDir(dir: string): Promise<string[]> {

--- a/packages/committee-generator/test/committee-validate.test.ts
+++ b/packages/committee-generator/test/committee-validate.test.ts
@@ -47,8 +47,8 @@ describe('Committee validator', () => {
   });
 
   it('Should fail with out of order keys', () => {
-    let unsortedKeys = getCommitteeFixture();
-    // @ts-ignore
+    const unsortedKeys = getCommitteeFixture();
+    // @ts-expect-error - testing out of order keys
     delete unsortedKeys.registryId;
     unsortedKeys.registryId = getCommitteeFixture().registryId + 100;
     expect(() => validateCommitteeString(JSON.stringify(unsortedKeys))).toThrow(
@@ -99,7 +99,7 @@ describe('Committee validator', () => {
 
   it('Should fail without missing required keys', () => {
     const testCommittee = getCommitteeFixture();
-    // @ts-ignore
+    // @ts-expect-error - testing missing required key
     delete testCommittee.networkGenesisHash;
     expect(() => validateCommitteeString(JSON.stringify(testCommittee))).toThrow(
       `Committee JSON did not pass schema validation: must have required property 'networkGenesisHash'`,

--- a/packages/committee-generator/test/s3/ensure-committee-shortcuts.test.ts
+++ b/packages/committee-generator/test/s3/ensure-committee-shortcuts.test.ts
@@ -104,7 +104,7 @@ describe('ensureCommitteeShortcuts', () => {
     const { getCommitteeID } = await import('../../src/committee');
     const { committeeIdToSafeFileName } = await import('../../src/utils');
     const committeeID = getCommitteeID(committeeData);
-    const safeCommitteeID = committeeIdToSafeFileName(Buffer.from(committeeID, 'base64'));
+    const safeCommitteeID = committeeIdToSafeFileName(committeeID);
     const committeeIDKey = getExpectedKey(`committee/${safeCommitteeID}.json`);
 
     // Upload all three files (original + both shortcuts)

--- a/packages/committee-generator/test/setup-files.ts
+++ b/packages/committee-generator/test/setup-files.ts
@@ -63,10 +63,14 @@ beforeAll(async () => {
     const s3Client = getOrCreateS3Client();
     await s3Client.send(new CreateBucketCommand({ Bucket: TEST_BUCKET_NAME }));
     console.log('[setupFiles beforeAll] Bucket created/verified');
-  } catch (error: any) {
-    // Bucket already exists is OK, but other errors should fail immediately
-    if (error.name !== 'BucketAlreadyExists' && error.name !== 'BucketAlreadyOwnedByYou') {
-      throw error;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      // Bucket already exists is OK, but other errors should fail immediately
+      if (error.name !== 'BucketAlreadyExists' && error.name !== 'BucketAlreadyOwnedByYou') {
+        throw error;
+      }
+    } else {
+      throw new Error('Unexpected error during bucket creation', { cause: error });
     }
   }
 });


### PR DESCRIPTION
- `loadPage` was refactored so the executor function is no longer async. https://github.com/algorandfoundation/xgov-committees/commit/886aed03b962f1110f249ea9a6b22ccf3de69d90
- various ESlint errors fixed in https://github.com/algorandfoundation/xgov-committees/commit/9de09328327204044c909ecbf8d1cd0201822561
- some typescript errors suppressed (regarding committeeID to preserve original behavior - no functional changes made)
- fixed issues with the root `package.json` (pnpm args were in wrong order to run lint/fmt correctly)
- husky pre-commit fixed to run the root/workspace version of the format,lint,build steps. (previously using filter)
- CI fixed to run the root/workspace version of format, lint and build steps. (previously using filter)

**CI jobs now passing correctly**