### PR TITLE
fix: get production ready + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,38 @@
 # ─── Shared (used by both packages) ──────────────────────
-ALGOD_SERVER=https://mainnet-api.4160.nodely.dev
-ALGOD_PORT=443
+ALGOD_SERVER=
+ALGOD_PORT=
 ALGOD_TOKEN=
-REGISTRY_APP_ID=3147789458
+REGISTRY_APP_ID=
+
+# Code defaults on config.ts
+# ALGOD_SERVER=https://mainnet-api.4160.nodely.dev
+# ALGOD_PORT=443
+# ALGOD_TOKEN=
+# REGISTRY_APP_ID=3147789458
 
 # ─── Runner ────────────────────────────────────────────────────────────────────
 STATE_DIR=
-# defaults to /opt/xgov-committees/packages/committee-generator/dist/index.js
 COMMITTEE_GENERATOR_PATH=
 SLACK_BOT_TOKEN=
 SLACK_CHANNEL_ID=
 
+# Code defaults on config.ts
+# STATE_DIR=/var/lib/xgov-committees-runner
+# COMMITTEE_GENERATOR_PATH=/opt/xgov-committees/packages/committee-generator/dist/src/index.js
+
 # ─── Committee-generator ───────────────────────────────────────────────────────
 DATA_PATH=
-CONCURRENCY=5
+CONCURRENCY=
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_REGION=
 S3_BUCKET_NAME=
 S3_ENDPOINT=
 S3_PUBLIC_URL=
+
+# Code defaults on config.ts
+# DATA_PATH=/var/cache/xgov-committees/data
+# CONCURRENCY=5
 
 # Standalone invocation only (runner passes these as CLI args)
 # MODE=

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ S3_BUCKET_NAME=
 S3_ENDPOINT=
 S3_PUBLIC_URL=
 
-# Code defaults on config.ts
+# Recommended defaults for production
 # DATA_PATH=/var/cache/xgov-committees/data
 # CONCURRENCY=5
 

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ SLACK_CHANNEL_ID=
 
 # Code defaults on config.ts
 # STATE_DIR=/var/lib/xgov-committees-runner
-# COMMITTEE_GENERATOR_PATH=/opt/xgov-committees/packages/committee-generator/dist/src/index.js
+# COMMITTEE_GENERATOR_PATH=/opt/xgov-committees/packages/committee-generator/dist/index.js
 
 # ─── Committee-generator ───────────────────────────────────────────────────────
 DATA_PATH=

--- a/README.md
+++ b/README.md
@@ -1,67 +1,31 @@
-# xgov-committees
+# xGov Committees
 
-A monorepo for Algorand xGov committee generation and validation tools.
+Monorepo for automating Algorand [xGov](https://xgov.algorand.co) [committee file](https://arc.algorand.foundation/ARCs/arc-0086#representation) generation. Produces the xGov committee file for each governance period using an archival node, based on block proposer data and subscribed xGovs in the [xGov Registry](https://docs.xgov.algorand.co/specs/xgov-registry).
 
-## Overview
+The committee declaration on the xGov Registry is out of scope of this monorepo and is handled by a cron CI job on [algorandfoundation/xgov-beta-sc](https://github.com/algorandfoundation/xgov-beta-sc) repository.
 
-This repository contains tools for producing xGov committee files for Algorand governance cohorts using archival node data.
-
-## Repository Structure
-
-```
-xgov-committees/
-├── packages/
-│   └── committee-generator/          # Main committee generation package
-│       ├── src/
-│       │   ├── algod.ts              # Algod node interactions
-│       │   ├── blocks.ts             # Block header fetching
-│       │   ├── proposers.ts          # Proposer data aggregation
-│       │   ├── candidate-committee.ts # Candidate committee generation
-│       │   ├── subscribed-xgovs.ts   # xGov subscription queries
-│       │   ├── committee.ts          # Committee file generation
-│       │   ├── config.ts             # Configuration handling
-│       │   └── cache/                # Caching utilities (S3 & local)
-│       ├── test/                     # Test files (vitest)
-│       ├── package.json
-│       ├── tsconfig.json
-│       └── run.sh                    # CLI entry point
-├── package.json                      # Root workspace config
-├── tsconfig.json                     # Root TypeScript config
-└── .gitignore
-```
-
-## Workspace Setup
-
-This is a pnpm workspaces monorepo. All packages are located in the `packages/` directory.
-
-### Install Dependencies
-
-```bash
-pnpm install
-```
-
-### Build
-
-```bash
-pnpm run build
-```
-
-### Test
-
-```bash
-pnpm run test
-```
-
-## Key Packages
+## Packages
 
 ### committee-generator
 
-Main package for:
+Fetches block headers from an archival node, aggregates proposer data, and produces ARC-86 committee files. Uploads data to a public S3-like bucket.
 
-- Fetching block headers from archival nodes
-- Aggregating proposer data
-- Generating candidate committees
-- Querying subscribed xGov members
-- Creating and validating committee files
+See [`packages/committee-generator`](packages/committee-generator/README.md).
 
-See `packages/committee-generator/README.md` for detailed usage.
+### runner
+
+Systemd service that tracks governance periods and automatically drives the committee generator. Handles bootstrapping from an empty bucket, incremental cache warming, and Slack failure notifications.
+
+See [`packages/runner`](packages/runner/README.md).
+
+## Setup
+
+```bash
+pnpm install
+pnpm run build
+pnpm test
+```
+
+## Deploy
+
+See [`packages/runner/systemd/DEPLOY.md`](packages/runner/systemd/DEPLOY.md).

--- a/packages/committee-generator/package.json
+++ b/packages/committee-generator/package.json
@@ -13,7 +13,7 @@
     "node": ">=20.19.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/committee-generator/src/algod.ts
+++ b/packages/committee-generator/src/algod.ts
@@ -1,5 +1,5 @@
 import { Algodv2 } from 'algosdk';
-import { config } from './config';
+import { config } from './config.ts';
 
 export const algod = new Algodv2(config.algodToken, config.algodServer, config.algodPort);
 

--- a/packages/committee-generator/src/blocks.ts
+++ b/packages/committee-generator/src/blocks.ts
@@ -1,18 +1,20 @@
 import pMap from 'p-map';
-import { config } from './config';
-import { algod, networkMetadata } from './algod';
-import { subtractCached, getCache, setCache } from './cache';
-import { chunk, clearLine, formatDuration, sleep } from './utils';
-import { BlockHeader, modelsv2 } from 'algosdk';
-import { guardWhileNotShuttingDown, fatalError } from './shutdown';
+import { config } from './config.ts';
+import { algod, networkMetadata } from './algod.ts';
+import { subtractCached, getCache, setCache } from './cache/index.ts';
+import { chunk, clearLine, formatDuration, sleep } from './utils.ts';
+import { type BlockHeader, modelsv2 } from 'algosdk';
+import { guardWhileNotShuttingDown, fatalError } from './shutdown.ts';
 
 /**
  * Error thrown when attempting to fetch a block beyond the blockchain tip.
  */
 export class TipReachedError extends Error {
-  constructor(public readonly blockNumber: bigint) {
+  readonly blockNumber: bigint;
+  constructor(blockNumber: bigint) {
     super(`Block ${blockNumber} not available. The tip of the blockchain has been reached.`);
     this.name = 'TipReachedError';
+    this.blockNumber = blockNumber;
   }
 }
 

--- a/packages/committee-generator/src/cache/cache-manager.ts
+++ b/packages/committee-generator/src/cache/cache-manager.ts
@@ -1,8 +1,8 @@
 import { join } from 'path';
-import { CACHE_MAX_PAGES, CACHE_PAGE_SIZE, CachePage } from './cache-page';
-import { getCachePath } from './utils';
-import { fsExists, sleep } from '../utils';
-import { config } from '../config';
+import { CACHE_MAX_PAGES, CACHE_PAGE_SIZE, CachePage } from './cache-page.ts';
+import { getCachePath } from './utils.ts';
+import { fsExists, sleep } from '../utils.ts';
+import { config } from '../config.ts';
 
 export function getPageStartRnd(rnd: number) {
   return Math.floor(rnd / CACHE_PAGE_SIZE) * CACHE_PAGE_SIZE;

--- a/packages/committee-generator/src/cache/cache-page.ts
+++ b/packages/committee-generator/src/cache/cache-page.ts
@@ -1,10 +1,10 @@
 import { readFile, writeFile } from 'fs/promises';
-import { hashBuffer } from './utils';
-import { fsExists, getMD5Hash } from '../utils';
-import { config } from '../config';
+import { hashBuffer } from './utils.ts';
+import { fsExists, getMD5Hash } from '../utils.ts';
+import { config } from '../config.ts';
 import { basename } from 'path';
-import { getKeyWithNetworkMetadata, uploadData, getMD5HashForObject } from '../s3';
-import { CachePagePayload, fetchPageFromS3 } from './s3-cache';
+import { getKeyWithNetworkMetadata, uploadData, getMD5HashForObject } from '../s3/index.ts';
+import { type CachePagePayload, fetchPageFromS3 } from './s3-cache.ts';
 
 export const CACHE_PAGE_SIZE = 1_000;
 export const CACHE_MAX_PAGES = 10;

--- a/packages/committee-generator/src/cache/index.ts
+++ b/packages/committee-generator/src/cache/index.ts
@@ -1,9 +1,9 @@
 import { readFile, readdir, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { encodeJSON, decodeJSON, BlockHeader } from 'algosdk';
-import { chunk, clearLine, fsExists, sleep } from '../utils';
-import { getCachePath } from './utils';
-import { cacheManager, getPageStartRnd } from './cache-manager';
+import { chunk, clearLine, fsExists, sleep } from '../utils.ts';
+import { getCachePath } from './utils.ts';
+import { cacheManager, getPageStartRnd } from './cache-manager.ts';
 
 export const getCachedRounds = async (min: number, max: number): Promise<Set<number>> => {
   process.stderr.write('Reading block cache, please wait. This can take a while.');

--- a/packages/committee-generator/src/cache/s3-cache.ts
+++ b/packages/committee-generator/src/cache/s3-cache.ts
@@ -1,13 +1,17 @@
 import { join } from 'path';
-import { config } from '../config';
-import { getKeyWithNetworkMetadata, getMD5HashForObject, getPublicUrlForObject } from '../s3';
-import { clearLine, downloadToFile, formatDuration, fsExists, getMD5Hash } from '../utils';
+import { config } from '../config.ts';
+import {
+  getKeyWithNetworkMetadata,
+  getMD5HashForObject,
+  getPublicUrlForObject,
+} from '../s3/index.ts';
+import { clearLine, downloadToFile, formatDuration, fsExists, getMD5Hash } from '../utils.ts';
 import pMap from 'p-map';
-import { ensureCacheSubPathExists } from '.';
-import { getCachePath } from './utils';
-import { CACHE_PAGE_SIZE } from './cache-page';
+import { ensureCacheSubPathExists } from './index.ts';
+import { getCachePath } from './utils.ts';
+import { CACHE_PAGE_SIZE } from './cache-page.ts';
 import { readFile } from 'fs/promises';
-import { cacheManager } from './cache-manager';
+import { cacheManager } from './cache-manager.ts';
 
 export type CachePagePayload = Record<string, string>;
 

--- a/packages/committee-generator/src/cache/utils.ts
+++ b/packages/committee-generator/src/cache/utils.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
-import { config } from '../config';
-import { networkMetadata } from '../algod';
+import { config } from '../config.ts';
+import { networkMetadata } from '../algod.ts';
 
 export const getCachePath = (subPath: string): string => {
   const { genesisID, genesisHash } = networkMetadata;

--- a/packages/committee-generator/src/candidate-committee.ts
+++ b/packages/committee-generator/src/candidate-committee.ts
@@ -1,10 +1,10 @@
 import { join } from 'path';
-import { ensureCacheSubPathExists } from './cache';
-import { getCachePath } from './cache/utils';
+import { ensureCacheSubPathExists } from './cache/index.ts';
+import { getCachePath } from './cache/utils.ts';
 import { readFile, writeFile } from 'fs/promises';
-import { ProposerMap } from './proposers';
-import { clearLine, fsExists } from './utils';
-import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3';
+import { type ProposerMap } from './proposers.ts';
+import { clearLine, fsExists } from './utils.ts';
+import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3/index.ts';
 
 export type CandidateCommittee = Record<string, number>;
 

--- a/packages/committee-generator/src/committee-validate.ts
+++ b/packages/committee-generator/src/committee-validate.ts
@@ -1,8 +1,10 @@
 import { decodeAddress } from 'algosdk';
-import { Committee } from './committee';
-import { isEqual } from './utils';
-import Ajv from 'ajv';
-import { committeeSchema } from './committee-schema';
+import { type Committee } from './committee.ts';
+import { isEqual } from './utils.ts';
+import _Ajv from 'ajv';
+import { committeeSchema } from './committee-schema.ts';
+
+const Ajv = _Ajv.default ?? _Ajv;
 
 export function validateCommitteeString(committeeStr: string): Committee {
   // no whitespace in committee
@@ -19,7 +21,7 @@ export function validateCommitteeString(committeeStr: string): Committee {
   const validate = new Ajv().compile(committeeSchema);
   if (!validate(committee)) {
     throw new Error(
-      `Committee JSON did not pass schema validation: ${validate.errors!.map((e) => e.message)}`,
+      `Committee JSON did not pass schema validation: ${validate.errors!.map((e: { message?: string }) => e.message)}`,
     );
   }
 

--- a/packages/committee-generator/src/committee.ts
+++ b/packages/committee-generator/src/committee.ts
@@ -1,13 +1,13 @@
 import { join } from 'path';
-import { ensureCacheSubPathExists } from './cache';
-import { getCachePath } from './cache/utils';
+import { ensureCacheSubPathExists } from './cache/index.ts';
+import { getCachePath } from './cache/utils.ts';
 import { readFile, writeFile } from 'fs/promises';
-import { networkMetadata } from './algod';
-import { CandidateCommittee } from './candidate-committee';
-import { clearLine, fsExists, sha512_256_raw } from './utils';
-import { validateCommitteeString } from './committee-validate';
-import { XGovsRecord } from './subscribed-xgovs';
-import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3';
+import { networkMetadata } from './algod.ts';
+import { type CandidateCommittee } from './candidate-committee.ts';
+import { clearLine, fsExists, sha512_256_raw } from './utils.ts';
+import { validateCommitteeString } from './committee-validate.ts';
+import { type XGovsRecord } from './subscribed-xgovs.ts';
+import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3/index.ts';
 
 export type Committee = {
   networkGenesisHash: string;

--- a/packages/committee-generator/src/index.ts
+++ b/packages/committee-generator/src/index.ts
@@ -1,7 +1,7 @@
-import { TipReachedError } from './blocks';
-import { ensureCacheSubPathExists } from './cache';
-import { CacheMode, config } from './config';
-import { runUseCache, runValidateCache, runWriteCache } from './modes';
+import { TipReachedError } from './blocks.ts';
+import { ensureCacheSubPathExists } from './cache/index.ts';
+import { type CacheMode, config } from './config.ts';
+import { runUseCache, runValidateCache, runWriteCache } from './modes/index.ts';
 import {
   ExitCode,
   expectedExit,
@@ -10,7 +10,7 @@ import {
   enableAsyncTracking,
   ShuttingDownError,
   awaitShutdown,
-} from './shutdown';
+} from './shutdown.ts';
 
 const { cacheMode, fromBlock, toBlock } = config;
 

--- a/packages/committee-generator/src/modes/index.ts
+++ b/packages/committee-generator/src/modes/index.ts
@@ -1,3 +1,3 @@
-export { runUseCache } from './use-cache';
-export { runValidateCache } from './validate-cache';
-export { runWriteCache } from './write-cache';
+export { runUseCache } from './use-cache.ts';
+export { runValidateCache } from './validate-cache.ts';
+export { runWriteCache } from './write-cache.ts';

--- a/packages/committee-generator/src/modes/use-cache.ts
+++ b/packages/committee-generator/src/modes/use-cache.ts
@@ -1,9 +1,9 @@
-import { CACHE_PAGE_SIZE } from '../cache/cache-page';
-import { downloadBlockPages } from '../cache/s3-cache';
-import { loadCandidateCommittee, saveCandidateCommittee } from '../candidate-committee';
-import { loadCommittee, saveCommittee } from '../committee';
-import { loadProposers, saveProposers } from '../proposers';
-import { loadSubscribedXgovs, saveSubscribedXgovs } from '../subscribed-xgovs';
+import { CACHE_PAGE_SIZE } from '../cache/cache-page.ts';
+import { downloadBlockPages } from '../cache/s3-cache.ts';
+import { loadCandidateCommittee, saveCandidateCommittee } from '../candidate-committee.ts';
+import { loadCommittee, saveCommittee } from '../committee.ts';
+import { loadProposers, saveProposers } from '../proposers.ts';
+import { loadSubscribedXgovs, saveSubscribedXgovs } from '../subscribed-xgovs.ts';
 
 /**
  * Trust the artifacts on S3, downloading everything to the local cache (if not already present).

--- a/packages/committee-generator/src/modes/validate-cache.ts
+++ b/packages/committee-generator/src/modes/validate-cache.ts
@@ -1,20 +1,24 @@
 import pMap from 'p-map';
-import { getBlocks } from '../blocks';
-import { getCachedRounds } from '../cache';
-import { cacheManager } from '../cache/cache-manager';
-import { CACHE_PAGE_SIZE } from '../cache/cache-page';
-import { validateBlockPage } from '../cache/s3-cache';
+import { getBlocks } from '../blocks.ts';
+import { getCachedRounds } from '../cache/index.ts';
+import { cacheManager } from '../cache/cache-manager.ts';
+import { CACHE_PAGE_SIZE } from '../cache/cache-page.ts';
+import { validateBlockPage } from '../cache/s3-cache.ts';
 import {
   getCandidateCommittee,
   saveCandidateCommittee,
   loadCandidateCommittee,
-} from '../candidate-committee';
-import { getCommittee, saveCommittee, loadCommittee, getCommitteeID } from '../committee';
-import { getBlockProposers, saveProposers, serializeProposers } from '../proposers';
-import { getSubscribedXgovs, saveSubscribedXgovs, loadSubscribedXgovs } from '../subscribed-xgovs';
-import { getMD5Hash, makeRndsArray } from '../utils';
-import { config } from '../config';
-import { getKeyWithNetworkMetadata, getMD5HashForObject } from '../s3';
+} from '../candidate-committee.ts';
+import { getCommittee, saveCommittee, loadCommittee, getCommitteeID } from '../committee.ts';
+import { getBlockProposers, saveProposers, serializeProposers } from '../proposers.ts';
+import {
+  getSubscribedXgovs,
+  saveSubscribedXgovs,
+  loadSubscribedXgovs,
+} from '../subscribed-xgovs.ts';
+import { getMD5Hash, makeRndsArray } from '../utils.ts';
+import { config } from '../config.ts';
+import { getKeyWithNetworkMetadata, getMD5HashForObject } from '../s3/index.ts';
 
 const { registryAppId } = config;
 

--- a/packages/committee-generator/src/modes/write-cache.ts
+++ b/packages/committee-generator/src/modes/write-cache.ts
@@ -1,16 +1,20 @@
-import { getBlocks } from '../blocks';
-import { cacheManager } from '../cache/cache-manager';
+import { getBlocks } from '../blocks.ts';
+import { cacheManager } from '../cache/cache-manager.ts';
 import {
   loadCandidateCommittee,
   getCandidateCommittee,
   saveCandidateCommittee,
-} from '../candidate-committee';
-import { loadCommittee, getCommittee, saveCommittee, getCommitteeID } from '../committee';
-import { config } from '../config';
-import { loadProposers, getBlockProposers, saveProposers } from '../proposers';
-import { ensureCommitteeShortcuts } from '../s3';
-import { loadSubscribedXgovs, getSubscribedXgovs, saveSubscribedXgovs } from '../subscribed-xgovs';
-import { makeRndsArray, committeeIdToSafeFileName } from '../utils';
+} from '../candidate-committee.ts';
+import { loadCommittee, getCommittee, saveCommittee, getCommitteeID } from '../committee.ts';
+import { config } from '../config.ts';
+import { loadProposers, getBlockProposers, saveProposers } from '../proposers.ts';
+import { ensureCommitteeShortcuts } from '../s3/index.ts';
+import {
+  loadSubscribedXgovs,
+  getSubscribedXgovs,
+  saveSubscribedXgovs,
+} from '../subscribed-xgovs.ts';
+import { makeRndsArray, committeeIdToSafeFileName } from '../utils.ts';
 
 const { registryAppId } = config;
 

--- a/packages/committee-generator/src/proposers.ts
+++ b/packages/committee-generator/src/proposers.ts
@@ -1,13 +1,13 @@
 import pMap from 'p-map';
-import { getBlock } from './blocks';
-import { chunk, clearLine, fsExists, makeRndsArray, sleep } from './utils';
+import { getBlock } from './blocks.ts';
+import { chunk, clearLine, fsExists, makeRndsArray, sleep } from './utils.ts';
 import { writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
-import { ensureCacheSubPathExists } from './cache';
-import { getCachePath } from './cache/utils';
-import { CACHE_PAGE_SIZE } from './cache/cache-page';
-import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3';
-import { guardWhileNotShuttingDown } from './shutdown';
+import { ensureCacheSubPathExists } from './cache/index.ts';
+import { getCachePath } from './cache/utils.ts';
+import { CACHE_PAGE_SIZE } from './cache/cache-page.ts';
+import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3/index.ts';
+import { guardWhileNotShuttingDown } from './shutdown.ts';
 
 export type ProposerMap = Map<string, number[]>;
 

--- a/packages/committee-generator/src/s3/index.ts
+++ b/packages/committee-generator/src/s3/index.ts
@@ -1,22 +1,22 @@
 import {
-  _Object,
+  type _Object,
   CopyObjectCommand,
   DeleteObjectsCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
-  S3ClientConfig,
+  type S3ClientConfig,
 } from '@aws-sdk/client-s3';
-import { networkMetadata } from '../algod';
-import { config } from '../config';
+import { networkMetadata } from '../algod.ts';
+import { config } from '../config.ts';
 import { createReadStream } from 'fs';
 import { stat as fsStat } from 'fs/promises';
 import pMap from 'p-map';
-import { formatBytes } from '../cache/utils';
-import { committeeIdToSafeFileName, getMD5Hash, walkDir } from '../utils';
+import { formatBytes } from '../cache/utils.ts';
+import { committeeIdToSafeFileName, getMD5Hash, walkDir } from '../utils.ts';
 import { relative } from 'path';
-import { getCommitteeID, loadCommittee } from '../committee';
+import { getCommitteeID, loadCommittee } from '../committee.ts';
 
 // Initialize S3 client
 let s3Client: S3Client | null = null;

--- a/packages/committee-generator/src/shutdown.ts
+++ b/packages/committee-generator/src/shutdown.ts
@@ -1,5 +1,5 @@
 import { createHook } from 'async_hooks';
-import { shutdownCache } from './cache/cache-manager';
+import { shutdownCache } from './cache/cache-manager.ts';
 
 export const ExitCode = {
   SUCCESS: 0,

--- a/packages/committee-generator/src/subscribed-xgovs.ts
+++ b/packages/committee-generator/src/subscribed-xgovs.ts
@@ -1,13 +1,13 @@
 import { decodeUint64, encodeAddress } from 'algosdk';
-import { algod } from './algod';
-import { config } from './config';
+import { algod } from './algod.ts';
+import { config } from './config.ts';
 import pMap from 'p-map';
-import { getCachePath } from './cache/utils';
-import { ensureCacheSubPathExists } from './cache';
+import { getCachePath } from './cache/utils.ts';
+import { ensureCacheSubPathExists } from './cache/index.ts';
 import { join } from 'path';
 import { readFile, writeFile } from 'fs/promises';
-import { clearLine, fsExists } from './utils';
-import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3';
+import { clearLine, fsExists } from './utils.ts';
+import { getKeyWithNetworkMetadata, getPublicUrlForObject, uploadData } from './s3/index.ts';
 
 /*
     Gets subscribed xGovs from registry contract

--- a/packages/committee-generator/src/utils.ts
+++ b/packages/committee-generator/src/utils.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { createWriteStream } from 'fs';
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
-import { BinaryLike, createHash } from 'crypto';
+import { type BinaryLike, createHash } from 'crypto';
 
 export async function fsExists(path: string) {
   try {

--- a/packages/committee-generator/test/blocks.test.ts
+++ b/packages/committee-generator/test/blocks.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TipReachedError, isGenuineTipReached } from '../src/blocks';
-import { createTipReachedMock } from './test-helpers';
+import { TipReachedError, isGenuineTipReached } from '../src/blocks.ts';
+import { createTipReachedMock } from './test-helpers.ts';
 
 // Mock modules before importing the functions under test
-vi.mock('../src/config', () => ({
+vi.mock('../src/config.ts', () => ({
   config: {
     concurrency: 5,
     algodServer: 'http://localhost',
@@ -12,19 +12,19 @@ vi.mock('../src/config', () => ({
   },
 }));
 
-vi.mock('../src/cache', () => ({
+vi.mock('../src/cache/index.ts', () => ({
   getCache: vi.fn(),
   setCache: vi.fn(),
   subtractCached: vi.fn(),
 }));
 
-vi.mock('../src/shutdown', () => ({
+vi.mock('../src/shutdown.ts', () => ({
   guardWhileNotShuttingDown: <T extends (...args: never[]) => unknown>(fn: T) => fn, // passthrough, no shutdown guard for tests
   isShuttingDown: vi.fn(() => false),
   fatalError: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../src/algod', () => ({
+vi.mock('../src/algod.ts', () => ({
   networkMetadata: {
     genesisID: 'mainnet-v1.0',
     genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
@@ -35,7 +35,7 @@ vi.mock('../src/algod', () => ({
   },
 }));
 
-vi.mock('../src/utils', () => ({
+vi.mock('../src/utils.ts', () => ({
   chunk: <T>(arr: T[], size: number) => {
     const chunks = [];
     for (let i = 0; i < arr.length; i += size) {
@@ -55,9 +55,9 @@ describe('blocks.ts - TipReachedError', () => {
 
   describe('getBlock', () => {
     it('should throw TipReachedError with correct block number when algod returns 404', async () => {
-      const { getCache } = await import('../src/cache');
-      const { algod } = await import('../src/algod');
-      const { getBlock } = await import('../src/blocks');
+      const { getCache } = await import('../src/cache/index.ts');
+      const { algod } = await import('../src/algod.ts');
+      const { getBlock } = await import('../src/blocks.ts');
 
       vi.mocked(getCache).mockResolvedValue(undefined);
       vi.mocked(algod.block).mockImplementation(createTipReachedMock());
@@ -72,9 +72,9 @@ describe('blocks.ts - TipReachedError', () => {
     });
 
     it('should rethrow non-404 errors', async () => {
-      const { getCache } = await import('../src/cache');
-      const { algod } = await import('../src/algod');
-      const { getBlock } = await import('../src/blocks');
+      const { getCache } = await import('../src/cache/index.ts');
+      const { algod } = await import('../src/algod.ts');
+      const { getBlock } = await import('../src/blocks.ts');
 
       vi.mocked(getCache).mockResolvedValue(undefined);
       vi.mocked(algod.block).mockReturnValue({
@@ -87,9 +87,9 @@ describe('blocks.ts - TipReachedError', () => {
     });
 
     it('should successfully return block when available from algod', async () => {
-      const { getCache, setCache } = await import('../src/cache');
-      const { algod, networkMetadata } = await import('../src/algod');
-      const { getBlock } = await import('../src/blocks');
+      const { getCache, setCache } = await import('../src/cache/index.ts');
+      const { algod, networkMetadata } = await import('../src/algod.ts');
+      const { getBlock } = await import('../src/blocks.ts');
 
       // Mock cache miss
       vi.mocked(getCache).mockResolvedValue(undefined);
@@ -121,9 +121,9 @@ describe('blocks.ts - TipReachedError', () => {
 
   describe('getBlocks', () => {
     it('should propagate TipReachedError when fetching multiple blocks', async () => {
-      const { getCache, subtractCached } = await import('../src/cache');
-      const { algod } = await import('../src/algod');
-      const { getBlocks } = await import('../src/blocks');
+      const { getCache, subtractCached } = await import('../src/cache/index.ts');
+      const { algod } = await import('../src/algod.ts');
+      const { getBlocks } = await import('../src/blocks.ts');
 
       // Mock cache to indicate no cached blocks
       vi.mocked(subtractCached).mockResolvedValue([99999990, 99999991, 99999992]);

--- a/packages/committee-generator/test/committee-validate.test.ts
+++ b/packages/committee-generator/test/committee-validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { validateCommitteeString } from '../src/committee-validate';
-import { Committee } from '../src/committee';
+import { validateCommitteeString } from '../src/committee-validate.ts';
+import type { Committee } from '../src/committee.ts';
 
 function getCommitteeFixture(): Committee {
   return {

--- a/packages/committee-generator/test/s3/ensure-committee-shortcuts.test.ts
+++ b/packages/committee-generator/test/s3/ensure-committee-shortcuts.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PutObjectCommand, ListObjectsV2Command, GetObjectCommand } from '@aws-sdk/client-s3';
-import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files';
-import { createCommitteeFixture, getExpectedKey, cleanupS3Prefix } from './helpers';
-import type { Committee } from '../../src/committee';
+import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files.ts';
+import { createCommitteeFixture, getExpectedKey, cleanupS3Prefix } from './helpers.ts';
+import type { Committee } from '../../src/committee.ts';
 
 // In-memory store for committee data (simulates S3) - use vi.hoisted to make it available to mocks
 const { committeeStore } = vi.hoisted(() => {
@@ -12,8 +12,8 @@ const { committeeStore } = vi.hoisted(() => {
 });
 
 // Mock the committee module to avoid algod dependencies
-vi.mock('../../src/committee', async (importOriginal) => {
-  const actual = (await importOriginal()) as typeof import('../../src/committee');
+vi.mock('../../src/committee.ts', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('../../src/committee.ts');
 
   return {
     ...actual,
@@ -58,7 +58,7 @@ describe('ensureCommitteeShortcuts', () => {
     );
 
     // Run the function
-    const { ensureCommitteeShortcuts } = await import('../../src/s3');
+    const { ensureCommitteeShortcuts } = await import('../../src/s3/index.ts');
     await ensureCommitteeShortcuts();
 
     // List all objects to verify shortcuts were created
@@ -101,8 +101,8 @@ describe('ensureCommitteeShortcuts', () => {
     const endRoundKey = getExpectedKey('committee/58005000.json');
 
     // Get the committee ID to create the ID-based shortcut
-    const { getCommitteeID } = await import('../../src/committee');
-    const { committeeIdToSafeFileName } = await import('../../src/utils');
+    const { getCommitteeID } = await import('../../src/committee.ts');
+    const { committeeIdToSafeFileName } = await import('../../src/utils.ts');
     const committeeID = getCommitteeID(committeeData);
     const safeCommitteeID = committeeIdToSafeFileName(committeeID);
     const committeeIDKey = getExpectedKey(`committee/${safeCommitteeID}.json`);
@@ -133,7 +133,7 @@ describe('ensureCommitteeShortcuts', () => {
     ]);
 
     // Run the function
-    const { ensureCommitteeShortcuts } = await import('../../src/s3');
+    const { ensureCommitteeShortcuts } = await import('../../src/s3/index.ts');
     await ensureCommitteeShortcuts();
 
     // List all objects - should still be 4 (no duplicates, includes index.json)
@@ -176,7 +176,7 @@ describe('ensureCommitteeShortcuts', () => {
     ]);
 
     // Run the function
-    const { ensureCommitteeShortcuts } = await import('../../src/s3');
+    const { ensureCommitteeShortcuts } = await import('../../src/s3/index.ts');
     await ensureCommitteeShortcuts();
 
     // List all objects - should now be 4 (original + both shortcuts + index.json)
@@ -222,7 +222,7 @@ describe('ensureCommitteeShortcuts', () => {
     ]);
 
     // Run the function
-    const { ensureCommitteeShortcuts } = await import('../../src/s3');
+    const { ensureCommitteeShortcuts } = await import('../../src/s3/index.ts');
     await ensureCommitteeShortcuts();
 
     // Fetch index.json

--- a/packages/committee-generator/test/s3/helpers.ts
+++ b/packages/committee-generator/test/s3/helpers.ts
@@ -1,11 +1,11 @@
-import type { Committee } from '../../src/committee';
+import type { Committee } from '../../src/committee.ts';
 import {
   DeleteObjectsCommand,
   ListObjectsV2Command,
   type ListObjectsV2CommandOutput,
   type S3Client,
 } from '@aws-sdk/client-s3';
-import { TEST_BUCKET_NAME, TEST_NETWORK_METADATA } from '../setup-files';
+import { TEST_BUCKET_NAME, TEST_NETWORK_METADATA } from '../setup-files.ts';
 
 export function createCommitteeFixture(
   fromRound: number,

--- a/packages/committee-generator/test/s3/s3-operations.test.ts
+++ b/packages/committee-generator/test/s3/s3-operations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
-import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files';
-import { getExpectedKey, cleanupS3Prefix } from './helpers';
+import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files.ts';
+import { getExpectedKey, cleanupS3Prefix } from './helpers.ts';
 
 // Reset S3 client and clean bucket before each test
 beforeEach(async () => {
@@ -28,7 +28,7 @@ describe('S3 Operations', () => {
         }),
       );
 
-      const { objectExists } = await import('../../src/s3');
+      const { objectExists } = await import('../../src/s3/index.ts');
       const exists = await objectExists(key);
 
       expect(exists).toBe(true);
@@ -37,7 +37,7 @@ describe('S3 Operations', () => {
     it('should return false when object does not exist', async () => {
       const key = getExpectedKey('test/does-not-exist.json');
 
-      const { objectExists } = await import('../../src/s3');
+      const { objectExists } = await import('../../src/s3/index.ts');
       const exists = await objectExists(key);
 
       expect(exists).toBe(false);
@@ -67,7 +67,7 @@ describe('S3 Operations', () => {
         ),
       ]);
 
-      const { listKeysWithPrefix } = await import('../../src/s3');
+      const { listKeysWithPrefix } = await import('../../src/s3/index.ts');
       const keys = await listKeysWithPrefix(prefix);
 
       expect(keys.size).toBeGreaterThanOrEqual(2);
@@ -78,7 +78,7 @@ describe('S3 Operations', () => {
     it('should return empty set when no objects match prefix', async () => {
       const prefix = getExpectedKey('test/empty-prefix/');
 
-      const { listKeysWithPrefix } = await import('../../src/s3');
+      const { listKeysWithPrefix } = await import('../../src/s3/index.ts');
       const keys = await listKeysWithPrefix(prefix);
 
       expect(keys.size).toBe(0);
@@ -104,7 +104,7 @@ describe('S3 Operations', () => {
       }
       await Promise.all(uploads);
 
-      const { listKeysWithPrefix } = await import('../../src/s3');
+      const { listKeysWithPrefix } = await import('../../src/s3/index.ts');
       const keys = await listKeysWithPrefix(prefix);
 
       expect(keys.size).toBe(fileCount);
@@ -130,7 +130,7 @@ describe('S3 Operations', () => {
         }),
       );
 
-      const { getMD5HashForObject } = await import('../../src/s3');
+      const { getMD5HashForObject } = await import('../../src/s3/index.ts');
       const md5 = await getMD5HashForObject(key);
 
       expect(md5).toBeDefined();
@@ -143,7 +143,7 @@ describe('S3 Operations', () => {
     it('should return undefined for non-existent object', async () => {
       const key = getExpectedKey('test/does-not-exist-md5.json');
 
-      const { getMD5HashForObject } = await import('../../src/s3');
+      const { getMD5HashForObject } = await import('../../src/s3/index.ts');
       const md5 = await getMD5HashForObject(key);
 
       expect(md5).toBeUndefined();
@@ -162,7 +162,7 @@ describe('S3 Operations', () => {
         }),
       );
 
-      const { getMD5HashForObject } = await import('../../src/s3');
+      const { getMD5HashForObject } = await import('../../src/s3/index.ts');
       const md5 = await getMD5HashForObject(key);
 
       // ETag should not contain quotes
@@ -176,7 +176,7 @@ describe('S3 Operations', () => {
       const key = getExpectedKey('test/upload.json');
       const testData = JSON.stringify({ test: 'upload' });
 
-      const { uploadData } = await import('../../src/s3');
+      const { uploadData } = await import('../../src/s3/index.ts');
 
       // Verify upload was performed
       const uploaded = await uploadData(key, testData);
@@ -198,7 +198,7 @@ describe('S3 Operations', () => {
       const key = getExpectedKey('test/upload-skip.json');
       const testData = JSON.stringify({ test: 'skip' });
 
-      const { uploadData } = await import('../../src/s3');
+      const { uploadData } = await import('../../src/s3/index.ts');
 
       // First upload
       const firstUploaded = await uploadData(key, testData);
@@ -225,7 +225,7 @@ describe('S3 Operations', () => {
       const key = getExpectedKey('test/upload-force.json');
       const testData = JSON.stringify({ test: 'force' });
 
-      const { uploadData } = await import('../../src/s3');
+      const { uploadData } = await import('../../src/s3/index.ts');
 
       // First upload
       const firstUploadResult = await uploadData(key, testData);
@@ -251,7 +251,7 @@ describe('S3 Operations', () => {
 
   describe('getKeyWithNetworkMetadata', () => {
     it('should generate correct key with network prefix', async () => {
-      const { getKeyWithNetworkMetadata } = await import('../../src/s3');
+      const { getKeyWithNetworkMetadata } = await import('../../src/s3/index.ts');
 
       const key = getKeyWithNetworkMetadata('committee/test.json');
       const expected = getExpectedKey('committee/test.json');
@@ -262,7 +262,7 @@ describe('S3 Operations', () => {
 
   describe('getPublicUrlForObject', () => {
     it('should generate correct public URL', async () => {
-      const { getPublicUrlForObject } = await import('../../src/s3');
+      const { getPublicUrlForObject } = await import('../../src/s3/index.ts');
 
       const url = getPublicUrlForObject('committee/test.json');
       const expectedKey = getExpectedKey('committee/test.json');
@@ -295,11 +295,11 @@ describe('S3 Operations', () => {
         ),
       ]);
 
-      const { deleteDirectory } = await import('../../src/s3');
+      const { deleteDirectory } = await import('../../src/s3/index.ts');
       await deleteDirectory(prefix);
 
       // Verify files were deleted
-      const { listKeysWithPrefix } = await import('../../src/s3');
+      const { listKeysWithPrefix } = await import('../../src/s3/index.ts');
       const keys = await listKeysWithPrefix(prefix);
 
       expect(keys.size).toBe(0);
@@ -308,7 +308,7 @@ describe('S3 Operations', () => {
     it('should handle empty directory without errors', async () => {
       const prefix = getExpectedKey('test/empty-delete/');
 
-      const { deleteDirectory } = await import('../../src/s3');
+      const { deleteDirectory } = await import('../../src/s3/index.ts');
 
       // Should not throw when deleting non-existent prefix
       await expect(deleteDirectory(prefix)).resolves.not.toThrow();

--- a/packages/committee-generator/test/s3/sync-directory.test.ts
+++ b/packages/committee-generator/test/s3/sync-directory.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
-import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files';
-import { getExpectedKey, cleanupS3Prefix } from './helpers';
+import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files.ts';
+import { getExpectedKey, cleanupS3Prefix } from './helpers.ts';
 import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -38,7 +38,7 @@ describe('syncDirectory', () => {
     await writeFile(join(tempDir, 'file1.json'), JSON.stringify({ test: 1 }));
     await writeFile(join(tempDir, 'file2.json'), JSON.stringify({ test: 2 }));
 
-    const { syncDirectory } = await import('../../src/s3');
+    const { syncDirectory } = await import('../../src/s3/index.ts');
     await syncDirectory(tempDir);
 
     // List all objects
@@ -62,7 +62,7 @@ describe('syncDirectory', () => {
     await writeFile(join(tempDir, 'existing.json'), JSON.stringify({ test: 'existing' }));
     await writeFile(join(tempDir, 'new.json'), JSON.stringify({ test: 'new' }));
 
-    const { syncDirectory } = await import('../../src/s3');
+    const { syncDirectory } = await import('../../src/s3/index.ts');
 
     // First sync - uploads both files
     await syncDirectory(tempDir);
@@ -111,7 +111,7 @@ describe('syncDirectory', () => {
     await writeFile(join(tempDir, 'subdir2', 'file2.json'), JSON.stringify({ level: 2 }));
     await writeFile(join(tempDir, 'subdir2', 'nested', 'deep.json'), JSON.stringify({ level: 3 }));
 
-    const { syncDirectory } = await import('../../src/s3');
+    const { syncDirectory } = await import('../../src/s3/index.ts');
     await syncDirectory(tempDir);
 
     // Verify all files uploaded with correct paths
@@ -134,7 +134,7 @@ describe('syncDirectory', () => {
     if (!tempDir) throw new Error('Temp directory not created');
 
     // Don't create any files - directory is empty
-    const { syncDirectory } = await import('../../src/s3');
+    const { syncDirectory } = await import('../../src/s3/index.ts');
 
     // Should not throw
     await syncDirectory(tempDir);
@@ -162,7 +162,7 @@ describe('syncDirectory', () => {
     }
     await Promise.all(promises);
 
-    const { syncDirectory } = await import('../../src/s3');
+    const { syncDirectory } = await import('../../src/s3/index.ts');
     await syncDirectory(tempDir);
 
     // Verify all files uploaded

--- a/packages/committee-generator/test/setup-files.ts
+++ b/packages/committee-generator/test/setup-files.ts
@@ -76,7 +76,7 @@ beforeAll(async () => {
 });
 
 // Setup config mock with cached endpoint
-vi.mock('../src/config', () => ({
+vi.mock('../src/config.ts', () => ({
   config: {
     cacheMode: 'write-cache' as const,
     registryAppId: 3147789458,
@@ -105,7 +105,7 @@ vi.mock('../src/config', () => ({
   },
 }));
 
-vi.mock('../src/algod', () => ({
+vi.mock('../src/algod.ts', () => ({
   networkMetadata: TEST_NETWORK_METADATA,
   algod: {
     getTransactionParams: () => ({
@@ -133,6 +133,6 @@ export function getGlobalLocalStack() {
 
 // Helper to reset S3 client singleton
 export async function resetS3ClientForTests() {
-  const { resetS3Client } = await import('../src/s3');
+  const { resetS3Client } = await import('../src/s3/index.ts');
   resetS3Client();
 }

--- a/packages/committee-generator/test/shutdown.test-helpers.ts
+++ b/packages/committee-generator/test/shutdown.test-helpers.ts
@@ -3,4 +3,4 @@
  * These functions are for testing purposes only and provide internal access to shutdown state.
  */
 
-export { __testInternals } from '../src/shutdown';
+export { __testInternals } from '../src/shutdown.ts';

--- a/packages/committee-generator/test/shutdown.test.ts
+++ b/packages/committee-generator/test/shutdown.test.ts
@@ -5,11 +5,11 @@ import {
   isShuttingDown,
   shutdown,
   ExitCode,
-} from '../src/shutdown';
-import { __testInternals } from './shutdown.test-helpers';
+} from '../src/shutdown.ts';
+import { __testInternals } from './shutdown.test-helpers.ts';
 
 // Mock the cache manager module before importing anything else
-vi.mock('../src/cache/cache-manager', () => ({
+vi.mock('../src/cache/cache-manager.ts', () => ({
   shutdownCache: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -27,7 +27,7 @@ describe('Shutdown Async Resource Tracking', () => {
     process.exit = exitMock;
 
     // Reset the mocked shutdownCache
-    const { shutdownCache } = await import('../src/cache/cache-manager');
+    const { shutdownCache } = await import('../src/cache/cache-manager.ts');
     vi.mocked(shutdownCache).mockClear();
     vi.mocked(shutdownCache).mockResolvedValue(undefined);
   });
@@ -276,7 +276,7 @@ describe('Shutdown Async Resource Tracking', () => {
     it('should complete shutdown and exit process', async () => {
       // Don't enable async tracking to allow quick completion
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-      const { shutdownCache } = await import('../src/cache/cache-manager');
+      const { shutdownCache } = await import('../src/cache/cache-manager.ts');
 
       // Start shutdown
       void shutdown(ExitCode.SUCCESS, 'expected', 'completion test');

--- a/packages/committee-generator/test/tip-reached-integration.test.ts
+++ b/packages/committee-generator/test/tip-reached-integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createTipReachedMock } from './test-helpers';
+import { createTipReachedMock } from './test-helpers.ts';
 
 // Mock all dependencies before importing modules
-vi.mock('../src/config', () => ({
+vi.mock('../src/config.ts', () => ({
   config: {
     cacheMode: 'write-cache' as const,
     registryAppId: 123456,
@@ -17,21 +17,21 @@ vi.mock('../src/config', () => ({
   },
 }));
 
-vi.mock('../src/cache', () => ({
+vi.mock('../src/cache/index.ts', () => ({
   getCache: vi.fn(),
   setCache: vi.fn(),
   subtractCached: vi.fn(),
   ensureCacheSubPathExists: vi.fn(),
 }));
 
-vi.mock('../src/cache/cache-manager', () => ({
+vi.mock('../src/cache/cache-manager.ts', () => ({
   cacheManager: {
     flushAllPages: vi.fn().mockResolvedValue(undefined),
   },
   shutdownCache: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../src/shutdown', () => ({
+vi.mock('../src/shutdown.ts', () => ({
   guardWhileNotShuttingDown: <T extends (...args: never[]) => unknown>(fn: T) => fn, // passthrough for tests
   isShuttingDown: vi.fn(() => false),
   ExitCode: {
@@ -47,7 +47,7 @@ vi.mock('../src/shutdown', () => ({
   awaitShutdown: vi.fn(),
 }));
 
-vi.mock('../src/algod', () => ({
+vi.mock('../src/algod.ts', () => ({
   networkMetadata: {
     genesisID: 'mainnet-v1.0',
     genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
@@ -58,7 +58,7 @@ vi.mock('../src/algod', () => ({
   },
 }));
 
-vi.mock('../src/utils', () => ({
+vi.mock('../src/utils.ts', () => ({
   chunk: <T>(arr: T[], size: number) => {
     const chunks = [];
     for (let i = 0; i < arr.length; i += size) {
@@ -79,32 +79,32 @@ vi.mock('../src/utils', () => ({
   committeeIdToSafeFileName: vi.fn((id: string) => id),
 }));
 
-vi.mock('../src/proposers', () => ({
+vi.mock('../src/proposers.ts', () => ({
   loadProposers: vi.fn().mockResolvedValue(null),
   getBlockProposers: vi.fn(),
   saveProposers: vi.fn(),
 }));
 
-vi.mock('../src/candidate-committee', () => ({
+vi.mock('../src/candidate-committee.ts', () => ({
   loadCandidateCommittee: vi.fn().mockResolvedValue(null),
   getCandidateCommittee: vi.fn(),
   saveCandidateCommittee: vi.fn(),
 }));
 
-vi.mock('../src/committee', () => ({
+vi.mock('../src/committee.ts', () => ({
   loadCommittee: vi.fn().mockResolvedValue(null),
   getCommittee: vi.fn(),
   saveCommittee: vi.fn(),
   getCommitteeID: vi.fn().mockReturnValue('test-committee-id'),
 }));
 
-vi.mock('../src/subscribed-xgovs', () => ({
+vi.mock('../src/subscribed-xgovs.ts', () => ({
   loadSubscribedXgovs: vi.fn().mockResolvedValue(null),
   getSubscribedXgovs: vi.fn(),
   saveSubscribedXgovs: vi.fn(),
 }));
 
-vi.mock('../src/s3', () => ({
+vi.mock('../src/s3/index.ts', () => ({
   ensureCommitteeShortcuts: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -114,9 +114,9 @@ describe('TipReachedError Integration Test', () => {
   });
 
   it('should propagate TipReachedError from getBlock through runWriteCache', async () => {
-    const { getCache, subtractCached } = await import('../src/cache');
-    const { algod } = await import('../src/algod');
-    const { runWriteCache } = await import('../src/modes/write-cache');
+    const { getCache, subtractCached } = await import('../src/cache/index.ts');
+    const { algod } = await import('../src/algod.ts');
+    const { runWriteCache } = await import('../src/modes/write-cache.ts');
 
     vi.mocked(subtractCached).mockResolvedValue([99999990, 99999991, 99999992]);
     vi.mocked(getCache).mockResolvedValue(undefined);

--- a/packages/committee-generator/tsconfig.build.json
+++ b/packages/committee-generator/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/committee-generator/tsconfig.json
+++ b/packages/committee-generator/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "./dist"
   },
-  "include": ["src", "test", "vitest.config.ts"]
+  "include": ["."],
+  "exclude": ["dist"]
 }

--- a/packages/runner/CONTRIBUTING.md
+++ b/packages/runner/CONTRIBUTING.md
@@ -57,12 +57,11 @@ Build and run:
 pnpm run build
 
 # Success — no Slack message
-node dist/notify-slack.js --exit-status 0 --service-result success --hostname local
+node dist/notify-slack.js --exit-status 0 --service-result success --hostname local --unit-name runner.service
 
 # Failure — posts to Slack
-node dist/notify-slack.js --exit-status 1 --service-result exit-code --hostname local
+node dist/notify-slack.js --exit-status 1 --service-result exit-code --hostname local --unit-name runner.service
 
 # Other failure types
-node dist/notify-slack.js --exit-status 0 --service-result timeout --hostname local
-node dist/notify-slack.js --exit-status 0 --service-result watchdog --hostname local
+node dist/notify-slack.js --exit-status 0 --service-result watchdog --hostname local --unit-name runner.service
 ```

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -6,11 +6,11 @@ Triggered by a systemd timer every 50 minutes. See [systemd/README.md](systemd/R
 
 ## How it works
 
-Per ARC-86, an xGov Committee is selected from a governance period `(Bi, Bf)` — the block range `[Bi; Bf)` from which xGov voting power is derived. Each xGov's voting power is proportional to the number of blocks they proposed in that range. Consecutive governance periods shift by 1M blocks: `(Bi, Bf)` → `(Bi+1M, Bf+1M)`, with `Bf - Bi = 3M` blocks (the committee selection range). Once the chain passes `Bf`, the cohort for that period can be computed and a new committee file is generated. Committee file generation is automatically handled by the `committee-generator` once a million round is surpassed.
+Per ARC-86, an xGov Committee is selected from a governance period `(Bi, Bf)` — the block range `[Bi; Bf)` from which xGov voting power is derived. Each xGov's voting power equals the number of blocks they proposed in that range. Consecutive governance periods shift by 1M blocks: `(Bi, Bf)` → `(Bi+1M, Bf+1M)`, with `Bf - Bi = 3M` blocks (the committee selection range). Once the chain passes `Bf`, the cohort for that period can be computed and a new committee file is generated. Committee file generation is automatically handled by the `committee-generator` once a million round is surpassed.
 
 The runner tracks the last fully processed governance period and warms the cache for the next one. On each invocation the service loop evaluates three ordered cases:
 
-1. **Catch-up**: If the chain is past the last processed period, process the full 3M block range immediately. This handles bootstrapping and periods that were missed while the service was offline.
+1. **Catch-up**: If the chain is past the last processed end round, process the full 3M block range immediately. This handles bootstrapping and periods that were missed while the service was offline.
 2. **Close to period end**: If the chain is within 900 blocks of a million round, wait for it and process the remaining period blocks + committee file generation.
 3. **100K warming**: If a 100K-block boundary has been crossed since the last write-cache call, run the `committee-generator` for the current governance period (even if not finished yet), expecting to reach the chain tip and exiting silently (`retryOnTip=false`). This keeps the block-header cache warm so that the final committee calculation at million round is fast.
 

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -76,12 +76,5 @@ Override via environment variables or an `.env` file at `/opt/xgov-committees/.e
 
 ## Deploy
 
-The service expects the full monorepo at `/opt/xgov-committees/`, built from the root with `pnpm install && pnpm run build` (builds both `runner` and `committee-generator`).
-
-**Requirements:**
-
-- Node.js >= 20.19.0 and pnpm on the server
-- A dedicated `xgov-committees-runner` system user (the service runs unprivileged)
-- A `.env` file at `/opt/xgov-committees/.env` with `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` (see [Configuration](#configuration)). Must be readable by the service user's group (`root:xgov-committees-runner`, mode `640`)
-- A state directory at `/var/lib/xgov-committees-runner` owned by the service user
-- The systemd units from `systemd/` installed in `/etc/systemd/system/` — see [systemd/README.md](systemd/README.md) for unit configuration details
+- See [systemd/DEPLOY.md](systemd/DEPLOY.md) for the full deployment playbook (production and test setup).
+- See [systemd/README.md](systemd/README.md) for unit configuration details.

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -43,6 +43,8 @@ pnpm run lint:fix     # lint + auto-fix
 pnpm run format       # format code
 ```
 
+> **Note:** `.prettierrc.json` mirrors the root config except for `printWidth` (120 vs 100) and `singleQuote` (false vs true).
+
 ## Testing
 
 ```bash

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,18 +1,18 @@
 # xGov Committees Runner
 
-A systemd service that tracks [ARC-86](https://dev.algorand.co/arc-standards/arc-0086/) governance periods and spawns the committee generator to build block-header caches and compute xGov committees.
+A systemd service that tracks [ARC-86](https://dev.algorand.co/arc-standards/arc-0086/) governance periods and spawns the `committee-generator` to build block-header caches, compute xGov committees and upload data to a public bucket.
 
 Triggered by a systemd timer every 50 minutes. See [systemd/README.md](systemd/README.md) for unit configuration.
 
 ## How it works
 
-Per ARC-86, an xGov Committee is selected from a governance period `(Bi, Bf)` — the block range `[Bi; Bf)` from which xGov voting power is derived. Each xGov's voting power equals the number of blocks they proposed in that range. Consecutive governance periods shift by 1M blocks: `(Bi, Bf)` → `(Bi+1M, Bf+1M)`, with `Bf - Bi = 3M` blocks (the committee selection range). Once the chain passes `Bf`, the committee for that period can be computed and a new committee file is generated.
+Per ARC-86, an xGov Committee is selected from a governance period `(Bi, Bf)` — the block range `[Bi; Bf)` from which xGov voting power is derived. Each xGov's voting power is proportional to the number of blocks they proposed in that range. Consecutive governance periods shift by 1M blocks: `(Bi, Bf)` → `(Bi+1M, Bf+1M)`, with `Bf - Bi = 3M` blocks (the committee selection range). Once the chain passes `Bf`, the cohort for that period can be computed and a new committee file is generated. Committee file generation is automatically handled by the `committee-generator` once a million round is surpassed.
 
 The runner tracks the last fully processed governance period and warms the cache for the next one. On each invocation the service loop evaluates three ordered cases:
 
-1. **Catch-up** — If the chain is already past `Bf`, process the full `[Bi; Bf)` range immediately. This handles bootstrapping and periods that were missed while the service was offline.
-2. **Close to period end** — If the chain is within 900 blocks of `Bf`, wait for it (plus a short buffer), then process the full range.
-3. **100K warming** — If a 100K-block boundary has been crossed since the last write-cache call, run the generator over `[Bi; Bf)` with `retryOnTip=false` (tip is expected and accepted silently). This keeps the block-header cache warm so that the final committee calculation at `Bf` is fast.
+1. **Catch-up**: If the chain is past the last processed period, process the full 3M block range immediately. This handles bootstrapping and periods that were missed while the service was offline.
+2. **Close to period end**: If the chain is within 900 blocks of a million round, wait for it and process the remaining period blocks + committee file generation.
+3. **100K warming**: If a 100K-block boundary has been crossed since the last write-cache call, run the `committee-generator` for the current governance period (even if not finished yet), expecting to reach the chain tip and exiting silently (`retryOnTip=false`). This keeps the block-header cache warm so that the final committee calculation at million round is fast.
 
 After each case the loop re-evaluates, so a single invocation can catch up across multiple governance periods and then warm the cache for the current one.
 
@@ -22,14 +22,14 @@ The runner persists a JSON state file per network/registry pair in `STATE_DIR`:
 
 ```json
 {
-  "lastGovernancePeriod": { "Bi": 56000000, "Bf": 59000000 },
+  "lastGovernancePeriod": { "startRound": 56000000, "endRound": 59000000 },
   "lastCacheRound": 59112478,
   "updatedAt": "2026-03-20T12:00:00.000Z"
 }
 ```
 
-- `lastGovernancePeriod` — the last fully processed governance period `(Bi, Bf)`.
-- `lastCacheRound` — the last round at which a successful write-cache call was made.
+- `lastGovernancePeriod`: the last fully processed governance period `(Bi, Bf)`.
+- `lastCacheRound`: the last round at which a successful write-cache call was made.
 
 On first run the runner bootstraps from the initial governance period `(50M, 53M)`.
 
@@ -61,7 +61,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for test architecture, coverage details, 
 
 ## Configuration
 
-All variables have production defaults except Slack credentials, which are **required**.
+All variables have defaults except Slack credentials, which are **required**.
 
 | Variable                   | Default                                                           | Description                      |
 | -------------------------- | ----------------------------------------------------------------- | -------------------------------- |
@@ -75,6 +75,8 @@ All variables have production defaults except Slack credentials, which are **req
 | `COMMITTEE_GENERATOR_PATH` | `/opt/xgov-committees/packages/committee-generator/dist/index.js` | Path to committee generator      |
 
 Override via environment variables or an `.env` file at `/opt/xgov-committees/.env` (loaded by the systemd unit).
+
+> For production, use the `.io` variant of the Nodely endpoint (`mainnet-api.4160.nodely.io`) with an API token.
 
 ## Deploy
 

--- a/packages/runner/src/notify-slack.ts
+++ b/packages/runner/src/notify-slack.ts
@@ -9,6 +9,7 @@ const argv = await yargs(hideBin(process.argv))
   .option("exit-status", { type: "string", demandOption: true })
   .option("service-result", { type: "string", demandOption: true })
   .option("hostname", { type: "string", demandOption: true })
+  .option("unit-name", { type: "string", demandOption: true })
   .strict()
   .parse();
 
@@ -19,7 +20,7 @@ try {
     exitStatus: argv.exitStatus,
     serviceResult: argv.serviceResult,
     hostname: argv.hostname,
-    unitName: "runner.service",
+    unitName: argv.unitName,
     slackBotToken: config.slackBotToken,
     slackChannelId: config.slackChannelId,
   });

--- a/packages/runner/src/slack.ts
+++ b/packages/runner/src/slack.ts
@@ -23,7 +23,7 @@ interface PostFailureNotificationArgs extends ExecStopPostArgs {
 }
 
 export function isFailure(serviceResult: string): boolean {
-  return serviceResult !== "success";
+  return serviceResult !== "success" && serviceResult !== "timeout";
 }
 
 export function getJournalTail(unitName: string): string {

--- a/packages/runner/src/utils.ts
+++ b/packages/runner/src/utils.ts
@@ -4,8 +4,8 @@ export const BLOCK_TOLERANCE_FOR_1M = 900; // 42m at 2.8s per block
  * Returns true if a 100K block boundary was crossed in the [from, to] interval.
  */
 export function crossed100KBoundary(from: number, to: number): boolean {
-  if (from < to) return Math.floor(to / 100_000) > Math.floor((from - 1) / 100_000);
-  throw new Error(`Invalid arguments: from (${from}) must be less than to (${to})`);
+  if (from <= to) return Math.floor(to / 100_000) > Math.floor((from - 1) / 100_000);
+  throw new Error(`Invalid arguments: from (${from}) must be less than or equal to (${to})`);
 }
 
 /**

--- a/packages/runner/systemd/DEPLOY.md
+++ b/packages/runner/systemd/DEPLOY.md
@@ -1,0 +1,214 @@
+# Deployment Playbook
+
+## Prerequisites
+
+- Ubuntu server with Node.js >= 20.19.0 and pnpm installed
+- `.env` file with all required variables (see `.env.example` at repo root)
+
+## Production Setup
+
+### 1. Create dedicated user
+
+```bash
+sudo useradd --system --no-create-home xgov-committees-runner
+```
+
+### 2. Deploy code
+
+```bash
+sudo git clone <repo-url> /opt/xgov-committees
+cd /opt/xgov-committees
+sudo pnpm install --frozen-lockfile
+sudo rm -rf packages/committee-generator/dist packages/runner/dist
+sudo pnpm run build
+```
+
+> All files under `/opt/xgov-committees` are root-owned. The service only needs read access. Code updates (`git pull`, `pnpm install`, `pnpm run build`) will also need `sudo`.
+
+### 3. Create data directories
+
+The service user can't create directories under `/var/lib/` or `/var/cache/`, so these must be done as root:
+
+```bash
+# Runner local state (persists across runs)
+sudo mkdir -p /var/lib/xgov-committees-runner
+sudo chown xgov-committees-runner: /var/lib/xgov-committees-runner
+
+# Generator block cache (read + write — stores block headers, proposers, committees)
+sudo mkdir -p /var/cache/xgov-committees/data
+sudo chown xgov-committees-runner: /var/cache/xgov-committees/data
+```
+
+### 4. Create .env
+
+```bash
+sudo cp /opt/xgov-committees/.env.example /opt/xgov-committees/.env
+# Edit with production values
+sudo chmod 600 /opt/xgov-committees/.env
+```
+
+> The file is root-owned with `600` permissions. This is intentional — systemd reads `EnvironmentFile` as root before dropping privileges to the service user.
+
+### 5. Install systemd units
+
+Copy (not symlink) so `git pull` doesn't change the running service definition:
+
+```bash
+sudo cp /opt/xgov-committees/packages/runner/systemd/runner.service /etc/systemd/system/xgov-committees-runner.service
+sudo cp /opt/xgov-committees/packages/runner/systemd/runner.timer /etc/systemd/system/xgov-committees-runner.timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now xgov-committees-runner.timer
+```
+
+### 6. Verify
+
+```bash
+systemctl status xgov-committees-runner.timer
+systemctl status xgov-committees-runner.service
+systemctl list-timers | grep xgov
+```
+
+## Test Setup (run as your user, e.g. `sofi`)
+
+### 1. Clone and build
+
+```bash
+cd ~
+git clone <repo-url> xgov-committees
+cd xgov-committees
+pnpm install --frozen-lockfile
+rm -rf packages/committee-generator/dist packages/runner/dist
+pnpm run build
+```
+
+> Always `rm -rf dist` before building. `tsc` doesn't delete stale output files, so old extensionless imports or moved files can linger and cause runtime errors.
+
+### 2. Create .env
+
+```bash
+cp .env.example .env
+# Edit with your values
+```
+
+In general, replace `/opt` with `/home/<user>` in paths (e.g. `COMMITTEE_GENERATOR_PATH`, `STATE_DIR`). Set `DATA_PATH` for generator's block cache conveniently.
+
+### 3. Install systemd units
+
+Symlink the service and timer (symlink lets repo changes take effect immediately):
+
+```bash
+sudo ln -s ~/xgov-committees/packages/runner/systemd/runner.service /etc/systemd/system/xgov-committees-runner.service
+sudo ln -s ~/xgov-committees/packages/runner/systemd/runner.timer /etc/systemd/system/xgov-committees-runner.timer
+```
+
+### 4. Create systemd override
+
+Override paths and user to run from user's home directory:
+
+```bash
+sudo systemctl edit xgov-committees-runner.service
+```
+
+Paste:
+
+```ini
+[Service]
+WorkingDirectory=/home/sofi/xgov-committees/packages/runner
+EnvironmentFile=
+EnvironmentFile=/home/sofi/xgov-committees/.env
+ExecStart=
+ExecStart=/usr/bin/node /home/sofi/xgov-committees/packages/runner/dist/index.js
+ExecStopPost=
+ExecStopPost=-/usr/bin/node /home/sofi/xgov-committees/packages/runner/dist/notify-slack.js --exit-status=${EXIT_STATUS} --service-result=${SERVICE_RESULT} --hostname=%H --unit-name=%n
+User=sofi
+SupplementaryGroups=systemd-journal
+```
+
+> The empty `ExecStart=` / `ExecStopPost=` / `EnvironmentFile=` lines clear the base unit's values before setting new ones. Without them, systemd appends and ends up with duplicate entries.
+
+> `SupplementaryGroups=systemd-journal` grants the service process read access to the journal, required for the Slack notifier to include log tails in failure notifications. Optionally, add your user to the group too (`sudo usermod -aG systemd-journal sofi`) to tail logs without `sudo`.
+
+### 5. Start
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl start xgov-committees-runner.timer
+```
+
+## Teardown (test setup)
+
+```bash
+sudo systemctl stop xgov-committees-runner.timer
+sudo systemctl stop xgov-committees-runner.service
+sudo systemctl disable xgov-committees-runner.timer
+sudo rm /etc/systemd/system/xgov-committees-runner.service
+sudo rm /etc/systemd/system/xgov-committees-runner.timer
+sudo rm -r /etc/systemd/system/xgov-committees-runner.service.d
+sudo systemctl daemon-reload
+```
+
+## Operations
+
+### View live logs
+
+```bash
+sudo journalctl -u xgov-committees-runner.service -f --output=cat
+```
+
+> Use `--output=cat` to see raw stdout without journald blob truncation.
+
+### Check status
+
+```bash
+systemctl list-timers | grep xgov
+systemctl list-units | grep xgov
+```
+
+### Stop
+
+```bash
+sudo systemctl stop xgov-committees-runner.timer
+sudo systemctl stop xgov-committees-runner.service
+```
+
+### Reset (after a failed run)
+
+```bash
+sudo systemctl reset-failed xgov-committees-runner.service
+```
+
+> Clears the `failed` state so the unit shows as `inactive`. The timer can then trigger it again.
+
+### Test Slack notifications
+
+Send SIGKILL to simulate a crash (triggers `ExecStopPost` with non-success result):
+
+```bash
+sudo systemctl start xgov-committees-runner.service
+# Wait a few seconds for it to start
+sudo systemctl kill --signal=SIGKILL xgov-committees-runner.service
+```
+
+> SIGTERM (normal stop) exits cleanly with code 0 — no Slack notification (by design).
+> SIGKILL exits with code 137 / `SERVICE_RESULT=signal` — Slack notification fires.
+
+### Code update
+
+```bash
+# Stop first to prevent a run mid-build
+sudo systemctl stop xgov-committees-runner.timer
+sudo systemctl stop xgov-committees-runner.service
+
+cd ~/xgov-committees  # or /opt/xgov-committees for production
+git pull
+pnpm install --frozen-lockfile
+rm -rf packages/committee-generator/dist packages/runner/dist
+pnpm run build
+
+# For production only: update systemd unit files if they changed
+# sudo cp packages/runner/systemd/runner.service /etc/systemd/system/xgov-committees-runner.service
+# sudo cp packages/runner/systemd/runner.timer /etc/systemd/system/xgov-committees-runner.timer
+
+sudo systemctl daemon-reload
+sudo systemctl start xgov-committees-runner.timer
+```

--- a/packages/runner/systemd/DEPLOY.md
+++ b/packages/runner/systemd/DEPLOY.md
@@ -23,18 +23,14 @@ sudo rm -rf packages/committee-generator/dist packages/runner/dist
 sudo pnpm run build
 ```
 
-> All files under `/opt/xgov-committees` are root-owned. The service only needs read access. Code updates (`git pull`, `pnpm install`, `pnpm run build`) will also need `sudo`.
+> All files under `/opt/xgov-committees` are root-owned. Code updates (`git pull`, `pnpm install`, `pnpm run build`) will also need `sudo`.
 
 ### 3. Create data directories
 
-The service user can't create directories under `/var/lib/` or `/var/cache/`, so these must be done as root:
-
 ```bash
-# Runner local state (persists across runs)
 sudo mkdir -p /var/lib/xgov-committees-runner
 sudo chown xgov-committees-runner: /var/lib/xgov-committees-runner
 
-# Generator block cache (read + write — stores block headers, proposers, committees)
 sudo mkdir -p /var/cache/xgov-committees/data
 sudo chown xgov-committees-runner: /var/cache/xgov-committees/data
 ```
@@ -47,7 +43,7 @@ sudo cp /opt/xgov-committees/.env.example /opt/xgov-committees/.env
 sudo chmod 600 /opt/xgov-committees/.env
 ```
 
-> The file is root-owned with `600` permissions. This is intentional — systemd reads `EnvironmentFile` as root before dropping privileges to the service user.
+> Root-owned with `600` — systemd reads `EnvironmentFile` as root before dropping privileges to the service user.
 
 ### 5. Install systemd units
 
@@ -65,10 +61,11 @@ sudo systemctl enable --now xgov-committees-runner.timer
 ```bash
 systemctl status xgov-committees-runner.timer
 systemctl status xgov-committees-runner.service
-systemctl list-timers | grep xgov
 ```
 
-## Test Setup (run as your user, e.g. `sofi`)
+## Test Setup
+
+Run as your own user (not root). Replace `<your-username>` with your actual username throughout.
 
 ### 1. Clone and build
 
@@ -81,7 +78,7 @@ rm -rf packages/committee-generator/dist packages/runner/dist
 pnpm run build
 ```
 
-> Always `rm -rf dist` before building. `tsc` doesn't delete stale output files, so old extensionless imports or moved files can linger and cause runtime errors.
+> Always `rm -rf dist` before building — `tsc` doesn't delete stale output files.
 
 ### 2. Create .env
 
@@ -90,45 +87,61 @@ cp .env.example .env
 # Edit with your values
 ```
 
-In general, replace `/opt` with `/home/<user>` in paths (e.g. `COMMITTEE_GENERATOR_PATH`, `STATE_DIR`). Set `DATA_PATH` for generator's block cache conveniently.
+Replace `/opt` with `/home/<your-username>` in paths (`COMMITTEE_GENERATOR_PATH`, `STATE_DIR`). Set `DATA_PATH` for the generator's block cache.
 
-### 3. Install systemd units
+### 3. Create data directories
 
-Symlink the service and timer (symlink lets repo changes take effect immediately):
+```bash
+mkdir -p ~/xgov-committees/packages/runner/state
+
+# Use whatever path you set as DATA_PATH in .env
+sudo mkdir -p /var/cache/xgov-committees/data
+sudo chown "$USER": /var/cache/xgov-committees/data
+```
+
+> If you delete these to reset, re-run to restore permissions.
+
+### 4. Install systemd units
 
 ```bash
 sudo ln -s ~/xgov-committees/packages/runner/systemd/runner.service /etc/systemd/system/xgov-committees-runner.service
 sudo ln -s ~/xgov-committees/packages/runner/systemd/runner.timer /etc/systemd/system/xgov-committees-runner.timer
 ```
 
-### 4. Create systemd override
-
-Override paths and user to run from user's home directory:
+### 5. Create systemd override
 
 ```bash
 sudo systemctl edit xgov-committees-runner.service
 ```
 
-Paste:
-
 ```ini
 [Service]
-WorkingDirectory=/home/sofi/xgov-committees/packages/runner
+WorkingDirectory=/home/<your-username>/xgov-committees/packages/runner
 EnvironmentFile=
-EnvironmentFile=/home/sofi/xgov-committees/.env
+EnvironmentFile=/home/<your-username>/xgov-committees/.env
 ExecStart=
-ExecStart=/usr/bin/node /home/sofi/xgov-committees/packages/runner/dist/index.js
+ExecStart=/usr/bin/node /home/<your-username>/xgov-committees/packages/runner/dist/index.js
 ExecStopPost=
-ExecStopPost=-/usr/bin/node /home/sofi/xgov-committees/packages/runner/dist/notify-slack.js --exit-status=${EXIT_STATUS} --service-result=${SERVICE_RESULT} --hostname=%H --unit-name=%n
-User=sofi
+ExecStopPost=-/usr/bin/node /home/<your-username>/xgov-committees/packages/runner/dist/notify-slack.js --exit-status=${EXIT_STATUS} --service-result=${SERVICE_RESULT} --hostname=%H --unit-name=%n
+User=<your-username>
 SupplementaryGroups=systemd-journal
 ```
 
-> The empty `ExecStart=` / `ExecStopPost=` / `EnvironmentFile=` lines clear the base unit's values before setting new ones. Without them, systemd appends and ends up with duplicate entries.
+> The empty lines clear the base unit's values before setting new ones — without them, systemd appends and you get duplicates.
 
-> `SupplementaryGroups=systemd-journal` grants the service process read access to the journal, required for the Slack notifier to include log tails in failure notifications. Optionally, add your user to the group too (`sudo usermod -aG systemd-journal sofi`) to tail logs without `sudo`.
+> `SupplementaryGroups=systemd-journal` lets the Slack notifier read the journal. Alternatively: `sudo usermod -aG systemd-journal <your-username>`.
 
-### 5. Start
+### 6. Override runtime limits (optional)
+
+```bash
+sudo systemctl edit xgov-committees-runner.service
+# Add under [Service]: RuntimeMaxSec=40min
+
+sudo systemctl edit xgov-committees-runner.timer
+# Add under [Timer]: OnUnitInactiveSec= (empty to clear) then OnUnitInactiveSec=10min
+```
+
+### 7. Start
 
 ```bash
 sudo systemctl daemon-reload
@@ -143,9 +156,19 @@ sudo systemctl stop xgov-committees-runner.service
 sudo systemctl disable xgov-committees-runner.timer
 sudo rm /etc/systemd/system/xgov-committees-runner.service
 sudo rm /etc/systemd/system/xgov-committees-runner.timer
-sudo rm -r /etc/systemd/system/xgov-committees-runner.service.d
+sudo rm -rf /etc/systemd/system/xgov-committees-runner.service.d
+sudo rm -rf /etc/systemd/system/xgov-committees-runner.timer.d
 sudo systemctl daemon-reload
 ```
+
+To also reset state and cache:
+
+```bash
+rm -rf ~/xgov-committees/packages/runner/state
+sudo rm -rf /var/cache/xgov-committees/data
+```
+
+> After deleting these, follow step 3 to recreate them with the correct permissions before restarting.
 
 ## Operations
 
@@ -155,13 +178,11 @@ sudo systemctl daemon-reload
 sudo journalctl -u xgov-committees-runner.service -f --output=cat
 ```
 
-> Use `--output=cat` to see raw stdout without journald blob truncation.
-
 ### Check status
 
 ```bash
-systemctl list-timers | grep xgov
-systemctl list-units | grep xgov
+systemctl status xgov-committees-runner.timer
+systemctl status xgov-committees-runner.service
 ```
 
 ### Stop
@@ -189,13 +210,11 @@ sudo systemctl start xgov-committees-runner.service
 sudo systemctl kill --signal=SIGKILL xgov-committees-runner.service
 ```
 
-> SIGTERM (normal stop) exits cleanly with code 0 — no Slack notification (by design).
-> SIGKILL exits with code 137 / `SERVICE_RESULT=signal` — Slack notification fires.
+> SIGTERM exits cleanly with code 0 — no Slack notification. SIGKILL exits with `SERVICE_RESULT=signal` — Slack notification fires.
 
 ### Code update
 
 ```bash
-# Stop first to prevent a run mid-build
 sudo systemctl stop xgov-committees-runner.timer
 sudo systemctl stop xgov-committees-runner.service
 

--- a/packages/runner/systemd/README.md
+++ b/packages/runner/systemd/README.md
@@ -50,10 +50,10 @@ ExecStart=/usr/bin/node /opt/xgov-committees/packages/runner/dist/index.js
 Absolute paths for both the Node binary and compiled entry point (no dependency on PATH). The TypeScript source MUST be compiled to JavaScript during the build step in CI/CD before deployment.
 
 ```ini
-ExecStopPost=-/usr/bin/node /opt/xgov-committees/packages/runner/dist/notify-slack.js --exit-status=${EXIT_STATUS} --service-result=${SERVICE_RESULT} --hostname=%H
+ExecStopPost=-/usr/bin/node /opt/xgov-committees/packages/runner/dist/notify-slack.js --exit-status=${EXIT_STATUS} --service-result=${SERVICE_RESULT} --hostname=%H --unit-name=%n
 ```
 
-Runs after the main process exits (regardless of success or failure) and posts a Slack notification on failure. `$EXIT_STATUS` and `$SERVICE_RESULT` are systemd environment variables available in `ExecStopPost`; `%H` is a specifier resolved to the machine hostname at unit parse time.
+Runs after the main process exits (regardless of success or failure) and posts a Slack notification on failure. `$EXIT_STATUS` and `$SERVICE_RESULT` are systemd environment variables available in `ExecStopPost`; `%H` and `%n` are specifiers resolved to the machine hostname and unit name at unit parse time.
 
 The `-` prefix makes this directive non-fatal: if `notify-slack` fails (e.g. Slack is down, env vars not configured), systemd ignores the non-zero exit and the unit's status reflects only the main service. Slack notifications are best-effort.
 

--- a/packages/runner/systemd/runner.service
+++ b/packages/runner/systemd/runner.service
@@ -9,7 +9,7 @@ NotifyAccess=all
 WorkingDirectory=/opt/xgov-committees/packages/runner
 EnvironmentFile=/opt/xgov-committees/.env
 ExecStart=/usr/bin/node /opt/xgov-committees/packages/runner/dist/index.js
-ExecStopPost=-/usr/bin/node /opt/xgov-committees/packages/runner/dist/notify-slack.js --exit-status=${EXIT_STATUS} --service-result=${SERVICE_RESULT} --hostname=%H
+ExecStopPost=-/usr/bin/node /opt/xgov-committees/packages/runner/dist/notify-slack.js --exit-status=${EXIT_STATUS} --service-result=${SERVICE_RESULT} --hostname=%H --unit-name=%n
 WatchdogSec=65
 WatchdogSignal=SIGTERM
 RuntimeMaxSec=3h

--- a/packages/runner/test/Dockerfile
+++ b/packages/runner/test/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt/xgov-committees
 RUN corepack enable
 
 # Install runner dependencies using the workspace root lock file.
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY packages/runner/package.json packages/runner/
 RUN pnpm install --frozen-lockfile --filter xgov-committees-runner
 

--- a/packages/runner/test/integration/integration.test.ts
+++ b/packages/runner/test/integration/integration.test.ts
@@ -255,7 +255,19 @@ describe("notify-slack", () => {
   it("exits 0 silently when service-result is success", () => {
     const result = spawnSync(
       "node",
-      ["--import", "tsx/esm", NOTIFY_SCRIPT, "--exit-status", "0", "--service-result", "success", "--hostname", "test"],
+      [
+        "--import",
+        "tsx/esm",
+        NOTIFY_SCRIPT,
+        "--exit-status",
+        "0",
+        "--service-result",
+        "success",
+        "--hostname",
+        "test",
+        "--unit-name",
+        "test.service",
+      ],
       { encoding: "utf8", env: notifySlackEnv() },
     );
     expect(result.status).toBe(0);
@@ -276,6 +288,8 @@ describe("notify-slack", () => {
         "exit-code",
         "--hostname",
         "test",
+        "--unit-name",
+        "test.service",
       ],
       { encoding: "utf8", env: { ...process.env, SLACK_BOT_TOKEN: "", SLACK_CHANNEL_ID: "" } },
     );
@@ -307,6 +321,8 @@ describe("notify-slack", () => {
         "exit-code",
         "--hostname",
         "integration-test",
+        "--unit-name",
+        "test.service",
       ],
       {
         encoding: "utf8",

--- a/packages/runner/test/unit/notify-slack.test.ts
+++ b/packages/runner/test/unit/notify-slack.test.ts
@@ -38,11 +38,11 @@ const baseArgs = {
 };
 
 describe("isFailure", () => {
-  it("returns false for 'success'", () => {
-    expect(isFailure("success")).toBe(false);
+  it.each(["success", "timeout"])("returns false for '%s'", (result) => {
+    expect(isFailure(result)).toBe(false);
   });
 
-  it.each(["exit-code", "signal", "timeout", "watchdog"])("returns true for '%s'", (result) => {
+  it.each(["exit-code", "signal", "watchdog", "core-dump", "start-limit-hit"])("returns true for '%s'", (result) => {
     expect(isFailure(result)).toBe(true);
   });
 });

--- a/packages/runner/test/unit/utils.test.ts
+++ b/packages/runner/test/unit/utils.test.ts
@@ -6,16 +6,18 @@ describe("crossed100KBoundary", () => {
     { from: 550_000, to: 599_999, expected: false, label: "within same window" },
     { from: 550_000, to: 699_999, expected: true, label: "crosses boundary" },
     { from: 550_000, to: 600_000, expected: true, label: "crosses boundary (`to` inclusive)" },
+    { from: 500_000, to: 500_001, expected: true, label: "one step after boundary (`to` inclusive)" },
     { from: 100_000, to: 150_000, expected: true, label: "crosses boundary (`from` inclusive)" },
     { from: 800_000, to: 1_000_500, expected: true, label: "crosses multiple boundaries" },
-    { from: 99_999, to: 100_000, expected: true, label: "one step to boundary" },
+    { from: 399_999, to: 400_000, expected: true, label: "one step to boundary" },
+    { from: 499_000, to: 499_000, expected: false, label: "same block, no boundary crossed" },
+    { from: 500_000, to: 500_000, expected: true, label: "same block, boundary crossed" },
   ])("$label: [$from, $to] → $expected", ({ from, to, expected }) => {
     expect(crossed100KBoundary(from, to)).toBe(expected);
   });
 
-  it("throws when from >= to", () => {
+  it("throws when from > to", () => {
     expect(() => crossed100KBoundary(100_001, 100_000)).toThrow();
-    expect(() => crossed100KBoundary(100_000, 100_000)).toThrow();
   });
 });
 

--- a/packages/runner/tsconfig.json
+++ b/packages/runner/tsconfig.json
@@ -1,20 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true,
-    "allowImportingTsExtensions": true,
-    "rewriteRelativeImportExtensions": true,
-    "outDir": "./dist",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true
+    "outDir": "./dist"
   },
   "include": ["."],
   "exclude": ["dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,19 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "sourceMap": true
   },
   "files": [],
   "references": [


### PR DESCRIPTION
Fixes and notes triggered by exercising test runs on the server.

- Switch root TS config to Node16 ESM settings and simplify per-package tsconfigs by extending the root one.
- Update committee-generator to use `.ts` import specifiers consistently and add committee-generator build-specific tsconfig.
- Improve runner behavior around 100K boundary by considering an edge case (discover this on a local test run, a race condition was taking place).
- Turn unit name as a parameter on `ExecStopPost`
- Enhance `.env.example` by providing defaults.
- Add deployment notes.