### PR TITLE
fix: s3 object content type

### DIFF
--- a/packages/committee-generator/src/committee.ts
+++ b/packages/committee-generator/src/committee.ts
@@ -116,7 +116,7 @@ export async function saveCommittee(
   if (to === 's3') {
     const key = getKeyWithNetworkMetadata(`${cacheSubPath}/${fromBlock}-${toBlock}.json`);
 
-    await uploadData(key, JSON.stringify(committee));
+    await uploadData(key, JSON.stringify(committee), false, 'application/json');
     return;
   }
 

--- a/packages/committee-generator/src/s3/index.ts
+++ b/packages/committee-generator/src/s3/index.ts
@@ -4,6 +4,7 @@ import {
   DeleteObjectsCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
+  MetadataDirective,
   PutObjectCommand,
   S3Client,
   type S3ClientConfig,
@@ -255,6 +256,8 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
                 Bucket: bucketName,
                 CopySource: `${bucketName}/${key}`,
                 Key: endRoundKey,
+                ContentType: 'application/json',
+                MetadataDirective: MetadataDirective.REPLACE, // Replace existing metadata
               }),
             )
             .then(() => {
@@ -275,6 +278,8 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
                 Bucket: bucketName,
                 CopySource: `${bucketName}/${key}`,
                 Key: committeeIDKey,
+                ContentType: 'application/json',
+                MetadataDirective: MetadataDirective.REPLACE, // Replace existing metadata
               }),
             )
             .then(() => {
@@ -316,7 +321,7 @@ export async function ensureCommitteeShortcuts(): Promise<void> {
     };
 
     const indexKey = getKeyWithNetworkMetadata('committee/index.json');
-    await uploadData(indexKey, JSON.stringify(indexData, null, 2));
+    await uploadData(indexKey, JSON.stringify(indexData, null, 2), false, 'application/json');
 
     if (config.verbose) {
       console.log(`Created committee index with ${indexEntries.length} committees at ${indexKey}`);
@@ -461,6 +466,7 @@ export async function getMD5HashForObject(key: string): Promise<string | undefin
  * @param key S3 key to upload under
  * @param data string or buffer data to upload
  * @param force if true, forces upload even if the object already exists (default: false)
+ * @param contentType optional MIME type of the content being uploaded
  * @throws Will throw an error if the upload fails
  * @returns {Promise<boolean>} Resolves when upload is completed or skipped due to existing identical object. Returns true if upload was performed, false if skipped.
  */
@@ -468,6 +474,7 @@ export async function uploadData(
   key: string,
   data: string | Uint8Array | Buffer,
   force: boolean = false,
+  contentType?: string,
 ): Promise<boolean> {
   const client = getS3Client();
   const { bucketName } = config.s3;
@@ -499,6 +506,7 @@ export async function uploadData(
       Bucket: bucketName,
       Key: key,
       Body: data,
+      ContentType: contentType,
     }),
   );
 

--- a/packages/committee-generator/test/s3/s3-operations.test.ts
+++ b/packages/committee-generator/test/s3/s3-operations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand, GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 import { getGlobalLocalStack, TEST_BUCKET_NAME, resetS3ClientForTests } from '../setup-files.ts';
 import { getExpectedKey, cleanupS3Prefix } from './helpers.ts';
 
@@ -246,6 +246,89 @@ describe('S3 Operations', () => {
 
       const uploadedData = await response.Body?.transformToString();
       expect(uploadedData).toBe(testData);
+    });
+
+    it('should set contentType correctly when provided', async () => {
+      const key = getExpectedKey('test/upload-content-type.json');
+      const testData = JSON.stringify({ test: 'contentType' });
+      const expectedContentType = 'application/json';
+
+      const { uploadData } = await import('../../src/s3/index.ts');
+
+      // Upload with specific contentType
+      const uploaded = await uploadData(key, testData, false, expectedContentType);
+      expect(uploaded).toBe(true);
+
+      // Verify the contentType was set correctly
+      const { s3Client } = getGlobalLocalStack();
+      const headResponse = await s3Client.send(
+        new HeadObjectCommand({
+          Bucket: TEST_BUCKET_NAME,
+          Key: key,
+        }),
+      );
+
+      expect(headResponse.ContentType).toBe(expectedContentType);
+    });
+
+    it('should handle different content types', async () => {
+      const { uploadData } = await import('../../src/s3/index.ts');
+      const { s3Client } = getGlobalLocalStack();
+
+      const testCases = [
+        {
+          key: getExpectedKey('test/upload-text.txt'),
+          data: 'plain text',
+          contentType: 'text/plain',
+        },
+        {
+          key: getExpectedKey('test/upload-image.png'),
+          data: Buffer.from([137, 80, 78, 71]),
+          contentType: 'image/png',
+        },
+        {
+          key: getExpectedKey('test/upload-csv.csv'),
+          data: 'col1,col2\nval1,val2',
+          contentType: 'text/csv',
+        },
+      ];
+
+      for (const testCase of testCases) {
+        const uploaded = await uploadData(testCase.key, testCase.data, false, testCase.contentType);
+        expect(uploaded).toBe(true);
+
+        const headResponse = await s3Client.send(
+          new HeadObjectCommand({
+            Bucket: TEST_BUCKET_NAME,
+            Key: testCase.key,
+          }),
+        );
+
+        expect(headResponse.ContentType).toBe(testCase.contentType);
+      }
+    });
+
+    it('should upload without contentType when not provided', async () => {
+      const key = getExpectedKey('test/upload-no-content-type.txt');
+      const testData = 'test data without content type';
+
+      const { uploadData } = await import('../../src/s3/index.ts');
+
+      // Upload without contentType
+      const uploaded = await uploadData(key, testData);
+      expect(uploaded).toBe(true);
+
+      // Verify the file was uploaded (contentType may be undefined or a default)
+      const { s3Client } = getGlobalLocalStack();
+      const headResponse = await s3Client.send(
+        new HeadObjectCommand({
+          Bucket: TEST_BUCKET_NAME,
+          Key: key,
+        }),
+      );
+
+      // If no contentType was provided, S3 may set it to a default or leave it undefined
+      expect(headResponse.ContentType).toBeDefined();
     });
   });
 


### PR DESCRIPTION
update the `uploadData` function, it now accepts an optional `contentType` parameter where content type can be specified.

**existing prod s3 bucket will manually set content type on existing committee artifacts**

- uploadData modified to accept content type as param
- committee files, shortcuts and committee `index.json` will now be set to application/json by default
- tests to ensure behavior is as expected