### PR TITLE
fix: update dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
 registry=https://registry.npmjs.org/
-ignore-scripts=true
-block-exotic-subdeps=true
-minimum-release-age=7200

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [`packages/runner`](packages/runner/README.md).
 
 ```bash
 pnpm install
-pnpm exec husky # once, .npmrc sets ignore-scripts=true, so git hooks aren't installed automatically
+pnpm exec husky # once, pnpm-workspace.yaml sets ignoreScripts: true, so git hooks aren't installed automatically
 pnpm run build
 pnpm test
 ```

--- a/package.json
+++ b/package.json
@@ -29,12 +29,5 @@
     "typescript-eslint": "^8.56.1",
     "vitest": "^4.0.18"
   },
-  "type": "module",
-  "pnpm": {
-    "overrides": {
-      "picomatch@<4.0.4": "^4.0.4",
-      "lodash@<4.18.0": "^4.18.0",
-      "axios@<1.15.0": "^1.15.0"
-    }
-  }
+  "type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  picomatch@<4.0.4: ^4.0.4
-  lodash@<4.18.0: ^4.18.0
-  axios@<1.15.0: ^1.15.0
-
 importers:
 
   .:
@@ -1548,7 +1543,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2019,8 +2014,8 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -3009,14 +3004,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@humanfs/core@0.19.1': {}
@@ -3987,7 +3982,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.6
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       tar-fs: 2.1.4
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -4587,7 +4582,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'packages/*'
 
-# vite ^8.0.5 fixes GHSA-v2wj-q39q-566r / GHSA-p9ff-h696-f583 (released 2026-04-06, remove once >5 days old)
-minimumReleaseAgeExclude:
-  - vite
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+ignoreScripts: true
+


### PR DESCRIPTION
Deps update since `pnpm audit` in CI was failing. Took the opportunity to use `pnpm-workspace.yaml` as is preferred by pnpm and remove redunant overrides.

Final goal is to deploy latest `main` version on the server.